### PR TITLE
doc: add information regarding cached credentials

### DIFF
--- a/bin/bugzilla
+++ b/bin/bugzilla
@@ -425,7 +425,7 @@ def setup_action_parser(action):
 
     elif action == 'login':
         p.set_usage('%prog login [username [password]]')
-        p.set_description("Log into bugzilla and save a login cookie.")
+        p.set_description("Log into bugzilla and save a login cookie or token.")
 
     if action in ['new', 'query']:
         outg = optparse.OptionGroup(p, "Output format options")
@@ -544,6 +544,23 @@ documentation in the 'SEE ALSO' section. Alternatively, run a 'bugzilla
 --debug query ...' and look at the key names returned in the query results.
 Also, in most cases, using the name of the associated command line switch
 should work, like --bug_status becomes %{bug_status}, etc.
+
+.SH AUTHENTICATION COOKIES AND TOKENS
+
+Older bugzilla instances use cookie-based authentication, and
+bugzilla.redhat.com uses a non-cookie token system.
+
+When you log into bugzilla with the "login" subcommand or the "--login"
+argument, we cache the cookie in ~/.bugzillacookies. If you are using
+bugzilla.redhat.com, we also cache the token in ~/.bugzillatoken.
+
+To perform an authenticated bugzilla command on a new machine, run a one time
+"bugzilla login" to cache credentials before running the desired command. You
+can also run "bugzilla --login" and the login process will be initiated before
+invoking the command.
+
+Additionally, the --no-cache-credentials option will tell the bugzilla tool to
+_not_ save any credentials to ~/.bugzillacookies or ~/.bugzillatoken.
 
 .SH EXAMPLES
 .PP

--- a/bugzilla.1
+++ b/bugzilla.1
@@ -322,6 +322,24 @@ documentation in the 'SEE ALSO' section. Alternatively, run a 'bugzilla
 Also, in most cases, using the name of the associated command line switch
 should work, like --bug_status becomes %{bug_status}, etc.
 
+.SH AUTHENTICATION COOKIES AND TOKENS
+
+Older bugzilla instances use cookie-based authentication, and
+bugzilla.redhat.com uses a non-cookie token system.
+
+When you log into bugzilla with the "login" subcommand or the "--login"
+argument, we cache the cookie in ~/.bugzillacookies. If you are using
+bugzilla.redhat.com, we also cache the token in ~/.bugzillatoken.
+
+To perform an authenticated bugzilla command on a new machine, run a one time
+"bugzilla login" to cache credentials before running the desired command. You
+can also run "bugzilla --login" and the login process will be initiated before
+invoking the command.
+
+Additionally, the --no-cache-credentials option will tell the bugzilla tool to
+_not_ save any credentials to ~/.bugzillacookies or ~/.bugzillatoken.
+
+
 .SH EXAMPLES
 .PP
 .RS 0


### PR DESCRIPTION
Update the bugzilla(1) man page to describe the location on disk where cookies or tokens are stored.

Update the "bugzilla login -h" text to indicate that cookies or tokens may be stored.