### PR TITLE
Add generic support for retrieving comments for bugs

### DIFF
--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -1070,6 +1070,12 @@ class BugzillaBase(object):
                 for b in self._getbugs(idlist, simple=True)]
 
 
+    def get_comments(self, idlist):
+        '''Returns a dictionary of bugs and comments.  The comments key will
+           be empty.  See bugzilla docs for details'''
+        return self._proxy.Bug.comments({'ids': idlist})
+
+
     #################
     # query methods #
     #################

--- a/bugzilla/bug.py
+++ b/bugzilla/bug.py
@@ -294,6 +294,16 @@ class _Bug(object):
 
         return self.bugzilla.update_bugs(self.bug_id, vals)
 
+    ################
+    # Get comments #
+    ################
+
+    def getcomments(self):
+        '''
+        Returns an array of comment dictionaries for this bug
+        '''
+        comment_list = self.bugzilla.get_comments([self.bug_id])
+        return comment_list['bugs'][str(self.bug_id)]['comments']
 
     ##########################
     # Get/set bug whiteboard #


### PR DESCRIPTION
This adds a new getcomments() method to Bug and a get_comments() method to the base Bugzilla class.  Since it's not compatible with the RH comments attribute, this may not be exactly the right fix...perhaps just renaming Bug.getcomments() to Bug.comments() would work?