### PR TITLE
remove type casting to bool to pass cert file

### DIFF
--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -420,7 +420,7 @@ class BugzillaBase(object):
         self._proxy = None
         self._transport = None
         self._cookiejar = None
-        self._sslverify = bool(sslverify)
+        self._sslverify = sslverify
         self._cache = _BugzillaAPICache()
         self._bug_autorefresh = True
 


### PR DESCRIPTION
Hello,

I wonder if we could pass a cert file name to sslverify parameter of __init__. Currently, the value is cast to bool, but as you may know, verify parameter of requests module can take a file/directory name of cert(s) as well as a boolean value. (See http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification). I know I can use REQUESTS_CA_BUNDLE environment variable, but it would be nice if I can specify the cert file explicitly. 

Thank you.