### PR TITLE
Flush stdout when prompting for username in interactive login

### DIFF
--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -574,6 +574,7 @@ class Bugzilla(object):
 
         if not user:
             sys.stdout.write('Bugzilla Username: ')
+            sys.stdout.flush()
             user = sys.stdin.readline().strip()
         if not password:
             password = getpass.getpass('Bugzilla Password: ')


### PR DESCRIPTION
Currently, when 'interactive_login' is called with the 'user' argument unset, the function waits for user input on his username without showing a prompt, leaving the user confused.
This PR adds a flush of stdout after writing the promt for the username. The same change is not needed for the password prompt, as the 'getpass' function flushes stdout properly.