### PR TITLE
Support Bugzilla API keys

### DIFF
--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -164,6 +164,10 @@ class Bugzilla(object):
       [bugzilla.yoursite.com]
       user = username
       password = password
+    Or
+      [bugzilla.yoursite.com]
+      api_key = key
+
     You can also use the [DEFAULT] section to set defaults that apply to
     any site without a specific section of its own.
     Be sure to set appropriate permissions on bugzillarc if you choose to
@@ -458,6 +462,9 @@ class Bugzilla(object):
             return
 
         for key, val in cfg.items(section):
+            if key == "api_key":
+                log.debug("bugzillarc: setting api_key")
+                self.api_key = val
             if key == "user":
                 log.debug("bugzillarc: setting user=%s", val)
                 self.user = val

--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -235,7 +235,7 @@ class Bugzilla(object):
         return url
 
     def __init__(self, url=-1, user=None, password=None, cookiefile=-1,
-                 sslverify=True, tokenfile=-1, use_creds=True):
+                 sslverify=True, tokenfile=-1, use_creds=True, api_key=None):
         """
         :param url: The bugzilla instance URL, which we will connect
             to immediately. Most users will want to specify this at
@@ -258,6 +258,7 @@ class Bugzilla(object):
         # Settings the user might want to tweak
         self.user = user or ''
         self.password = password or ''
+        self.api_key = api_key
         self.url = ''
 
         self._proxy = None
@@ -507,6 +508,10 @@ class Bugzilla(object):
             log.info("user and password present - doing login()")
             self.login()
 
+        if self.api_key:
+            log.debug("using API key")
+            self._proxy.use_api_key(self.api_key)
+
         version = self._proxy.Bugzilla.version()["version"]
         log.debug("Bugzilla version string: %s", version)
         self._set_bz_version(version)
@@ -542,6 +547,9 @@ class Bugzilla(object):
         and password are both set. So under most circumstances you won't need
         to call this yourself.
         '''
+        if self.api_key:
+            raise ValueError("cannot login when using an API key")
+
         if user:
             self.user = user
         if password:

--- a/bugzilla/transport.py
+++ b/bugzilla/transport.py
@@ -78,15 +78,22 @@ class _BugzillaServerProxy(ServerProxy):
         # No idea why pylint complains here, must be a bug
         ServerProxy.__init__(self, uri, *args, **kwargs)
         self.token_cache = _BugzillaTokenCache(uri, tokenfile)
+        self.api_key = None
+
+    def use_api_key(self, api_key):
+        self.api_key = api_key
 
     def clear_token(self):
         self.token_cache.token = None
 
     def _ServerProxy__request(self, methodname, params):
-        if self.token_cache.token is not None:
-            if len(params) == 0:
-                params = ({}, )
+        if len(params) == 0:
+            params = ({}, )
 
+        if self.api_key is not None:
+            if 'Bugzilla_api_key' not in params[0]:
+                params[0]['Bugzilla_api_key'] = self.api_key
+        elif self.token_cache.token is not None:
             if 'Bugzilla_token' not in params[0]:
                 params[0]['Bugzilla_token'] = self.token_cache.token
 

--- a/bugzilla/transport.py
+++ b/bugzilla/transport.py
@@ -28,7 +28,12 @@ class BugzillaError(Exception):
     pass
 
 
-class _BugzillaToken(object):
+class _BugzillaTokenCache(object):
+    """
+    Cache for tokens, including, with apologies for the duplicative
+    terminology, both Bugzilla Tokens and API Keys.
+    """
+
     def __init__(self, uri, tokenfilename):
         self.tokenfilename = tokenfilename
         self.tokenfile = SafeConfigParser()
@@ -63,7 +68,8 @@ class _BugzillaToken(object):
                 self.tokenfile.write(tokenfile)
 
     def __repr__(self):
-        return '<Bugzilla Token :: %s>' % (self.value)
+        return '<Bugzilla Token Cache :: %s, Bugzilla API Key :: %s>' % (
+                self.token, self.api_key)
 
 
 class _BugzillaServerProxy(ServerProxy):
@@ -71,25 +77,25 @@ class _BugzillaServerProxy(ServerProxy):
         # pylint: disable=super-init-not-called
         # No idea why pylint complains here, must be a bug
         ServerProxy.__init__(self, uri, *args, **kwargs)
-        self.token = _BugzillaToken(uri, tokenfile)
+        self.token_cache = _BugzillaTokenCache(uri, tokenfile)
 
     def clear_token(self):
-        self.token.value = None
+        self.token_cache.token = None
 
     def _ServerProxy__request(self, methodname, params):
-        if self.token.value is not None:
+        if self.token_cache.token is not None:
             if len(params) == 0:
                 params = ({}, )
 
             if 'Bugzilla_token' not in params[0]:
-                params[0]['Bugzilla_token'] = self.token.value
+                params[0]['Bugzilla_token'] = self.token_cache.token
 
         # pylint: disable=maybe-no-member
         ret = ServerProxy._ServerProxy__request(self, methodname, params)
         # pylint: enable=maybe-no-member
 
         if isinstance(ret, dict) and 'token' in ret.keys():
-            self.token.value = ret.get('token')
+            self.token_cache.token = ret.get('token')
         return ret
 
 

--- a/examples/apikey.py
+++ b/examples/apikey.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
+# the full text of the license.
+
+# create.py: Create a new bug report
+
+from __future__ import print_function
+
+import time
+
+import bugzilla
+
+# Don't worry, changing things here is fine, and won't send any email to
+# users or anything. It's what partner-bugzilla.redhat.com is for!
+URL = "https://landfill.bugzilla.org/bugzilla-5.0-branch/xmlrpc.cgi"
+
+print("You can get an API key at https://landfill.bugzilla.org/bugzilla-5.0-branch/userprefs.cgi")
+print("after creating an account, if necessary.  This is a test site, so no harm will come!")
+api_key = raw_input("Enter Bugzilla API Key: ")
+
+# API key usage assumes the API caller is storing the API key; if you would
+# like to use one of the login options that stores credentials on-disk for
+# command-line usage, use tokens or cookies.
+bzapi = bugzilla.Bugzilla(URL, api_key=api_key)
+assert bzapi.logged_in


### PR DESCRIPTION
Rather than encode my password in a dotfile, it would be great to use an [API key](https://bugzilla.mozilla.org/show_bug.cgi?id=893195) instead.
