### PR TITLE
escape illegal utf-8 character when getting response by xmlrpc

### DIFF
--- a/bugzilla/transport.py
+++ b/bugzilla/transport.py
@@ -163,7 +163,7 @@ class _RequestsTransport(Transport):
             # escape illegal utf-8 characters
             import re
             response._content = re.sub(b'[\x01-\x1f]+', '', response.content)
-            response._content = response.content.replace('&', '&amp;')
+            response._content = re.sub(b'&', '&amp;', response.content)
 
             # update/set any cookies
             if self._cookiejar is not None:

--- a/bugzilla/transport.py
+++ b/bugzilla/transport.py
@@ -162,7 +162,7 @@ class _RequestsTransport(Transport):
 
             # escape illegal utf-8 characters
             import re
-            response._content = re.sub("[\x01-\x1f]+", "", response.content)
+            response._content = re.sub(b'[\x01-\x1f]+', '', response.content)
             response._content = response.content.replace('&', '&amp;')
 
             # update/set any cookies

--- a/bugzilla/transport.py
+++ b/bugzilla/transport.py
@@ -162,8 +162,8 @@ class _RequestsTransport(Transport):
 
             # escape illegal utf-8 characters
             import re
-            response._content = re.sub(b'[\x01-\x1f]+', '', response.content)
-            response._content = re.sub(b'&', '&amp;', response.content)
+            response._content = re.sub(b'[\x01-\x1f]+', b'', response.content)
+            response._content = re.sub(b'&', b'&amp;', response.content)
 
             # update/set any cookies
             if self._cookiejar is not None:

--- a/bugzilla/transport.py
+++ b/bugzilla/transport.py
@@ -160,6 +160,11 @@ class _RequestsTransport(Transport):
             # We expect utf-8 from the server
             response.encoding = 'UTF-8'
 
+            # escape illegal utf-8 characters
+            import re
+            response._content = re.sub("[\x01-\x1f]+", "", response.content)
+            response._content = response.content.replace('&', '&amp;')
+
             # update/set any cookies
             if self._cookiejar is not None:
                 for cookie in response.cookies:


### PR DESCRIPTION
When I try to get the comment of Bug 6979 from netbeans, it returns errors which shows that the xml returned contains characters that cannot be parsed. So the response content should escape these illegal utf-8 characters.  Also can see the following site:
http://stackoverflow.com/questions/11443036/xml-parsing-in-python-expaterror-not-well-formed