### PR TITLE
Fix missing authentication regression

### DIFF
--- a/bugzilla/transport.py
+++ b/bugzilla/transport.py
@@ -83,7 +83,7 @@ class _BugzillaServerProxy(ServerProxy, object):
     def clear_token(self):
         self.token_cache.value = None
 
-    def __request(self, methodname, params):
+    def _ServerProxy__request(self, methodname, params):
         if len(params) == 0:
             params = ({}, )
 
@@ -94,7 +94,7 @@ class _BugzillaServerProxy(ServerProxy, object):
             if 'Bugzilla_token' not in params[0]:
                 params[0]['Bugzilla_token'] = self.token_cache.value
 
-        ret = super(_BugzillaServerProxy, self).__request(methodname, params)
+        ret = super(_BugzillaServerProxy, self)._ServerProxy__request(methodname, params)
 
         if isinstance(ret, dict) and 'token' in ret.keys():
             self.token_cache.value = ret.get('token')


### PR DESCRIPTION
Identifiers with a leading "__" are mangled, ensure that the original
method is overridden such that authentication tokens are added.

Fixes: v2.1.0-11-g3c692f4f4e ("_BugzillaServerProxy as new-style class")
___
This should have been caught by the rw test (#52).