### PR TITLE
Client side certificate support

### DIFF
--- a/bugzilla/_cli.py
+++ b/bugzilla/_cli.py
@@ -148,6 +148,8 @@ def _setup_root_parser():
              'specified command.')
     p.add_argument('--username', help="Log in with this username")
     p.add_argument('--password', help="Log in with this password")
+    p.add_argument('--cert', default=None, help="Log in with this "
+            "certificate")
 
     p.add_argument('--ensure-logged-in', action="store_true",
         help="Raise an error if we aren't logged in to bugzilla. "
@@ -1031,7 +1033,8 @@ def _make_bz_instance(opt):
         url=opt.bugzilla,
         cookiefile=cookiefile,
         tokenfile=tokenfile,
-        sslverify=opt.sslverify)
+        sslverify=opt.sslverify,
+        cert=opt.cert)
     return bz
 
 

--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -260,7 +260,7 @@ class Bugzilla(object):
 
 
     def __init__(self, url=-1, user=None, password=None, cookiefile=-1,
-                 sslverify=True, tokenfile=-1, use_creds=True, api_key=None):
+                 sslverify=True, tokenfile=-1, use_creds=True, api_key=None, cert=None):
         """
         :param url: The bugzilla instance URL, which we will connect
             to immediately. Most users will want to specify this at
@@ -268,6 +268,8 @@ class Bugzilla(object):
             url=None and calling connect(URL) manually
         :param user: optional username to connect with
         :param password: optional password for the connecting user
+        :param cert: optional certificate file for client side certificate
+            authentication
         :param cookiefile: Location to cache the login session cookies so you
             don't have to keep specifying username/password. Bugzilla 5+ will
             use tokens instead of cookies.
@@ -294,6 +296,7 @@ class Bugzilla(object):
         self.user = user or ''
         self.password = password or ''
         self.api_key = api_key
+        self.cert = cert or ''
         self.url = ''
 
         self._proxy = None
@@ -500,6 +503,9 @@ class Bugzilla(object):
             elif key == "password":
                 log.debug("bugzillarc: setting password")
                 self.password = val
+            elif key == "cert":
+                log.debug("bugzillarc: setting cert")
+                self.cert = val
             else:
                 log.debug("bugzillarc: unknown key=%s", key)
 
@@ -533,7 +539,7 @@ class Bugzilla(object):
         url = self.fix_url(url)
 
         self._transport = _RequestsTransport(
-            url, self._cookiejar, sslverify=self._sslverify)
+            url, self._cookiejar, sslverify=self._sslverify, cert=self.cert)
         self._transport.user_agent = self.user_agent
         self._proxy = _BugzillaServerProxy(url, self.tokenfile,
             self._transport)

--- a/bugzilla/transport.py
+++ b/bugzilla/transport.py
@@ -109,7 +109,7 @@ class _RequestsTransport(Transport):
     user_agent = 'Python/Bugzilla'
 
     def __init__(self, url, cookiejar=None,
-                 sslverify=True, sslcafile=None, debug=0):
+                 sslverify=True, sslcafile=None, debug=True, cert=None):
         if hasattr(Transport, "__init__"):
             Transport.__init__(self, use_datetime=False)
 
@@ -137,6 +137,8 @@ class _RequestsTransport(Transport):
         # Using an explicit Session, rather than requests.get, will use
         # HTTP KeepAlive if the server supports it.
         self.session = requests.Session()
+        if cert:
+            self.session.cert = cert
 
     def parse_response(self, response):
         """ Parse XMLRPC response """
@@ -167,6 +169,7 @@ class _RequestsTransport(Transport):
                     # Save is required only if we have a filename
                     self._cookiejar.save()
 
+            log.debug(response.text)
             response.raise_for_status()
             return self.parse_response(response)
         except requests.RequestException as e:


### PR DESCRIPTION
Adds the `cert` command line and configuration options that allow you to
specify a client-side certificate file to use for TLS authentication
against the web server.

File format should be concatenated certificate and (unencrypted) private
key. Encrypted private key should also be possible, but would have to
deal with passing the password along to `requests`, and I'm not
comfortable enough with Python to actually facilitate that.