### PR TITLE
Restricted Login

### DIFF
--- a/bugzilla/_cli.py
+++ b/bugzilla/_cli.py
@@ -152,6 +152,8 @@ def _setup_root_parser():
              'specified command.')
     p.add_argument('--username', help="Log in with this username")
     p.add_argument('--password', help="Log in with this password")
+    p.add_argument('--restrict-login', action="store_true",
+                   help="The session (login token) will be restricted to the current IP address.")
 
     p.add_argument('--ensure-logged-in', action="store_true",
         help="Raise an error if we aren't logged in to bugzilla. "
@@ -1059,7 +1061,7 @@ def _handle_login(opt, action, bz):
         if do_interactive_login:
             if bz.url:
                 print("Logging into %s" % urlparse(bz.url)[1])
-            bz.interactive_login(username, password)
+            bz.interactive_login(username, password, restrict=opt.restrict_login)
     except bugzilla.BugzillaError as e:
         print(str(e))
         sys.exit(1)

--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -606,13 +606,14 @@ class Bugzilla(object):
         except Fault as e:
             raise BugzillaError("Login failed: %s" % str(e.faultString))
 
-    def interactive_login(self, user=None, password=None, force=False):
+    def interactive_login(self, user=None, password=None, force=False, restrict=None):
         """
         Helper method to handle login for this bugzilla instance.
 
         :param user: bugzilla username. If not specified, prompt for it.
         :param password: bugzilla password. If not specified, prompt for it.
         :param force: Unused
+        :param restrict: restricts session to IP address
         """
         ignore = force
         log.debug('Calling interactive_login')
@@ -625,7 +626,7 @@ class Bugzilla(object):
             password = getpass.getpass('Bugzilla Password: ')
 
         log.info('Logging in... ')
-        self.login(user, password)
+        self.login(user, password, restrict)
         log.info('Authorization cookie received.')
 
     def logout(self):


### PR DESCRIPTION
Adds support to use restricted login, restricted to client's IP address. The restrict feature is available in Bugzilla since version 4.4.

Changes:
* `restrict` argument added to login methods
* `--restrict-login` option added to CLI

API Doc: https://bugzilla.redhat.com/docs/en/html/api/Bugzilla/WebService/User.html#login