### PR TITLE
WIP: Add -L / --comment-type / --long_desc_type

### DIFF
--- a/bugzilla/_cli.py
+++ b/bugzilla/_cli.py
@@ -228,6 +228,18 @@ def _parser_add_bz_fields(rootp, command):
     p.add_argument('-c', '--component', help="Component name")
     p.add_argument('-t', '--summary', '--short_desc', help="Bug summary")
     p.add_argument('-l', '--comment', '--long_desc', help=comment_help)
+    p.add_argument('-L', '--comment-type', '--long_desc_type',
+        help='--comment/--long_desc search semantics',
+        choices=[
+            'allwordssubstr',
+            'anywordssubstr',
+            'substring',
+            'casesubstring',
+            'allwords',
+            'anywords',
+            'regexp',
+            'notregexp',
+        ])
     if not cmd_query:
         p.add_argument("--comment-tag", action="append",
                 help="Comment tag for the new comment")
@@ -554,6 +566,7 @@ def _do_query(bz, opt, parser):
         bug_id=opt.id or None,
         short_desc=opt.summary or None,
         long_desc=opt.comment or None,
+        long_desc_type=opt.comment_type or None,
         cc=opt.cc or None,
         assigned_to=opt.assigned_to or None,
         qa_contact=opt.qa_contact or None,

--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -1109,6 +1109,7 @@ class Bugzilla(object):
                     component=None,
                     version=None,
                     long_desc=None,
+                    long_desc_type=None,
                     bug_id=None,
                     short_desc=None,
                     cc=None,
@@ -1243,7 +1244,9 @@ class Bugzilla(object):
         if long_desc is not None:
             query["query_format"] = "advanced"
             query["longdesc"] = long_desc
-            query["longdesc_type"] = "allwordssubstr"
+            if long_desc_type is None:
+                long_desc_type = 'allwordssubstr'
+            query['longdesc_type'] = long_desc_type
 
         # 'include_fields' only available for Bugzilla4+
         # 'extra_fields' is an RHBZ extension


### PR DESCRIPTION
So callers can override `longdesc_type` to get [different semantics][1].  The debug output seems to have this getting passed through:

```console
$ ./bugzilla-cli --debug --bugzilla https://bugzilla.redhat.com/xmlrpc.cgi query -p 'OpenShift Container Platform' -s NEW,ASSIGNED,POST -l 'ResourceQuota should create a ResourceQuota and capture the life of a secret' -L casesubstring
...
[23:25:46] DEBUG (base:554) Bugzilla version string: 5.0.4.rh14
[23:25:46] INFO (base:320) Using RHBugzilla for URL containing bugzilla.redhat.com
[23:25:46] DEBUG (transport:93) XMLRPC call: Bug.search({'product': ['OpenShift Container Platform'], 'longdesc': 'ResourceQuota should create a ResourceQuota and capture the life of a secret', 'bug_status': ['NEW', 'ASSIGNED', 'POST'], 'include_fields': ['assigned_to', 'id', 'status', 'summary'], 'longdesc_type': 'casesubstring', 'query_format': 'advanced'})
[23:25:49] DEBUG (base:1286) Query returned 2444 bugs
...
```

But that's a lot of matches.  I was expecting something closer to [this single match][2].  Is `longdesc_type` not actually supported by the XML RPC or something?

[1]: https://github.com/bugzilla/bugzilla/blob/release-5.1.2/template/en/default/search/form.html.tmpl#L31-L40
[2]: https://bugzilla.redhat.com/buglist.cgi?query_format=advanced&product=OpenShift%20Container%20Platform&longdesc_type=casesubstring&longdesc=ResourceQuota%20should%20create%20a%20ResourceQuota%20and%20capture%20the%20life%20of%20a%20secret