### PR TITLE
Fix path rules, add basic auth

### DIFF
--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -237,7 +237,7 @@ class Bugzilla(object):
 
     def __init__(self, url=-1, user=None, password=None, cookiefile=-1,
                  sslverify=True, tokenfile=-1, use_creds=True, api_key=None,
-                 cert=None, configpaths=-1):
+                 cert=None, configpaths=-1, basic_auth=False):
         """
         :param url: The bugzilla instance URL, which we will connect
             to immediately. Most users will want to specify this at
@@ -266,6 +266,7 @@ class Bugzilla(object):
             to file or directory for custom certs.
         :param api_key: A bugzilla5+ API key
         :param configpaths: A list of possible bugzillarc locations.
+        :param basic_auth: Use headers with HTTP Basic authentication
         """
         if url == -1:
             raise TypeError("Specify a valid bugzilla url, or pass url=None")
@@ -303,6 +304,7 @@ class Bugzilla(object):
         self.cookiefile = cookiefile
         self.tokenfile = tokenfile
         self.configpath = configpaths
+        self._basic_auth = basic_auth
 
         if url:
             self.connect(url)
@@ -536,6 +538,7 @@ class Bugzilla(object):
         self._transport = _RequestsTransport(
             url, self._cookiejar, sslverify=self._sslverify, cert=self.cert)
         self._transport.user_agent = self.user_agent
+
         self._proxy = _BugzillaServerProxy(url, self.tokenfile,
             self._transport)
 
@@ -567,6 +570,9 @@ class Bugzilla(object):
         """
         Backend login method for Bugzilla3
         """
+        if self._basic_auth:
+            self._transport.set_basic_auth(user, password)
+
         payload = {'login': user, 'password': password}
         if restrict_login:
             payload['restrict_login'] = True

--- a/bugzilla/transport.py
+++ b/bugzilla/transport.py
@@ -6,6 +6,8 @@
 
 from logging import getLogger
 import sys
+import base64
+import requests
 
 # pylint: disable=import-error
 if sys.version_info[0] >= 3:
@@ -17,8 +19,6 @@ else:
     from urlparse import urlparse
     from xmlrpclib import Fault, ProtocolError, ServerProxy, Transport
 # pylint: enable=import-error
-
-import requests
 
 
 log = getLogger(__name__)
@@ -142,6 +142,15 @@ class _RequestsTransport(Transport):
         self.session = requests.Session()
         if cert:
             self.session.cert = cert
+
+    def set_basic_auth(self, user, password):
+        """
+        Set basic authentication method.
+
+        :return:
+        """
+        self.request_defaults["headers"]["Authorization"] = "Basic {}".format(
+            str(base64.b64encode("{}:{}".format(user, password).encode("utf-8")).decode("utf-8")))
 
     def parse_response(self, response):
         """


### PR DESCRIPTION
This PR rewrites path rules in a standard way, using `urlparse/urlunparse` as well as adds sometimes required Basic authentication via headers, so the XML-RPC API URL can be at all accessed before even calling any functions.

Example usage:

```python
# coding: utf-8
import bugzilla
import getpass

bug_id = input("Bug ID: ")
user = input("Username: ")
pwd = getpass.getpass("Password: ")

bz = bugzilla.Bugzilla(url='https://apibugzilla.suse.com',
    user=user, password=pwd, basic_auth=True)
print(bz.getbug(bug_id).id)
```