### PR TITLE
Add --usekey support for bugzilla login API

### DIFF
--- a/bugzilla/_cli.py
+++ b/bugzilla/_cli.py
@@ -427,16 +427,19 @@ bugzilla attach --type=TYPE BUGID [BUGID...]"""
 
 
 def _setup_action_login_parser(subparsers):
-    usage = 'bugzilla login [username [password]]'
+    usage = 'bugzilla login [--use-key] [username [password]]'
     description = """Log into bugzilla and save a login cookie or token.
 Note: These tokens are short-lived, and future Bugzilla versions will no
-longer support token authentication at all. Please use a
-~/.config/python-bugzilla/bugzillarc file with an API key instead."""
+longer support token authentication at all. Please use an API key instead."""
     p = subparsers.add_parser("login", description=description, usage=usage)
-    p.add_argument("pos_username", nargs="?", help="Optional username",
-            metavar="username")
-    p.add_argument("pos_password", nargs="?", help="Optional password",
-            metavar="password")
+    p.add_argument('--use-key', action='store_true', default=False,
+                   help='Use an API-KEY instead of username/password.')
+    p.add_argument("pos_username", nargs="?", help="Optional username " \
+                   "(ignored if --use-key is provided)",
+                   metavar="username")
+    p.add_argument("pos_password", nargs="?", help="Optional password " \
+                   "(ignored if --use-key is provided)",
+                   metavar="password")
 
 
 def setup_parser():
@@ -1066,9 +1069,13 @@ def _handle_login(opt, action, bz):
         opt.login or opt.username or opt.password)
     username = getattr(opt, "pos_username", None) or opt.username
     password = getattr(opt, "pos_password", None) or opt.password
+    use_key = getattr(opt, "use_key", False)
 
     try:
-        if do_interactive_login:
+        if is_login_command and use_key:
+            bz.interactive_login(use_api_key=True,
+                    restrict_login=opt.restrict_login)
+        elif do_interactive_login:
             if bz.url:
                 print("Logging into %s" % urlparse(bz.url)[1])
             bz.interactive_login(username, password,


### PR DESCRIPTION
This change introduces a new feature for the command line client
and the Bugzilla python API.

In the python API, it changes the interactive_login method
to receive a new flag: "use_api_key" that, in case is defined will
ask the user to provide an API key instead of regular username/password.

In case the API_KEY provide works correctly, it will also
update the ~/config/python-bugzilla/bugzillarc file (or ~/.bugzillarc).

In the bugzilla-cli side, it will add a new parameter to the login
command: "--use-key". Use key will trigger the usage of this new python API.

Default behaviors were not change, neither in bugzilla-cli or the python
API.

This patch introduce the changes to fix issue #82