### PR TITLE
Add --usekey support for bugzilla login API

### DIFF
--- a/bugzilla/_cli.py
+++ b/bugzilla/_cli.py
@@ -427,16 +427,19 @@ bugzilla attach --type=TYPE BUGID [BUGID...]"""
 
 
 def _setup_action_login_parser(subparsers):
-    usage = 'bugzilla login [username [password]]'
+    usage = 'bugzilla login [--api-key] [username [password]]'
     description = """Log into bugzilla and save a login cookie or token.
 Note: These tokens are short-lived, and future Bugzilla versions will no
-longer support token authentication at all. Please use a
-~/.config/python-bugzilla/bugzillarc file with an API key instead."""
+longer support token authentication at all. Please use an API key instead."""
     p = subparsers.add_parser("login", description=description, usage=usage)
-    p.add_argument("pos_username", nargs="?", help="Optional username",
-            metavar="username")
-    p.add_argument("pos_password", nargs="?", help="Optional password",
-            metavar="password")
+    p.add_argument('--api-key', action='store_true', default=False,
+                   help='Use an API-KEY instead of username/password.')
+    p.add_argument("pos_username", nargs="?", help="Optional username " \
+                   "(ignored if --api-key is provided)",
+                   metavar="username")
+    p.add_argument("pos_password", nargs="?", help="Optional password " \
+                   "(ignored if --api-key is provided)",
+                   metavar="password")
 
 
 def setup_parser():
@@ -1066,9 +1069,13 @@ def _handle_login(opt, action, bz):
         opt.login or opt.username or opt.password)
     username = getattr(opt, "pos_username", None) or opt.username
     password = getattr(opt, "pos_password", None) or opt.password
+    use_key = getattr(opt, "api_key", False)
 
     try:
-        if do_interactive_login:
+        if is_login_command and use_key:
+            bz.interactive_login(use_api_key=True,
+                    restrict_login=opt.restrict_login)
+        elif do_interactive_login:
             if bz.url:
                 print("Logging into %s" % urlparse(bz.url)[1])
             bz.interactive_login(username, password,

--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -41,6 +41,12 @@ from .transport import BugzillaError, _BugzillaServerProxy, _RequestsTransport
 
 log = getLogger(__name__)
 
+def _parse_hostname(url):
+    # If http://example.com is passed, netloc=example.com path=""
+    # If just example.com is passed, netloc="" path=example.com
+    parsedbits = urlparse(url)
+    return parsedbits.netloc or parsedbits.path
+
 
 def _nested_update(d, u):
     # Helper for nested dict update()
@@ -52,14 +58,14 @@ def _nested_update(d, u):
     return d
 
 
-def _default_auth_location(filename):
+def _default_location(filename, kind='cache'):
     """
-    Determine auth location for filename, like 'bugzillacookies'. If
+    Determine default location for filename, like 'bugzillacookies'. If
     old style ~/.bugzillacookies exists, we use that, otherwise we
-    use ~/.cache/python-bugzilla/bugzillacookies. Same for bugzillatoken
+    use ~/.cache/python-bugzilla/bugzillacookies. Same for bugzillatoken and bugzilarc
     """
     homepath = os.path.expanduser("~/.%s" % filename)
-    xdgpath = os.path.expanduser("~/.cache/python-bugzilla/%s" % filename)
+    xdgpath = os.path.expanduser("~/.%s/python-bugzilla/%s" % (kind, filename))
     if os.path.exists(xdgpath):
         return xdgpath
     if os.path.exists(homepath):
@@ -294,9 +300,9 @@ class Bugzilla(object):
             configpaths = []
 
         if cookiefile == -1:
-            cookiefile = _default_auth_location("bugzillacookies")
+            cookiefile = _default_location("bugzillacookies")
         if tokenfile == -1:
-            tokenfile = _default_auth_location("bugzillatoken")
+            tokenfile = _default_location("bugzillatoken")
         if configpaths == -1:
             configpaths = _default_configpaths[:]
 
@@ -467,12 +473,6 @@ class Bugzilla(object):
         log.debug("bugzillarc: Searching for config section matching %s",
             self.url)
 
-        def _parse_hostname(_u):
-            # If http://example.com is passed, netloc=example.com path=""
-            # If just example.com is passed, netloc="" path=example.com
-            parsedbits = urlparse(self.url)
-            return parsedbits.netloc or parsedbits.path
-
         urlhost = _parse_hostname(self.url)
         for sectionhost in sorted(cfg.sections()):
             # If the section is just a hostname, make it match
@@ -626,8 +626,36 @@ class Bugzilla(object):
         except Fault as e:
             raise BugzillaError("Login failed: %s" % str(e.faultString))
 
+    def _save_api_key(self):
+        """
+        Save the API_KEY in the config file.
+
+        If toklenfile and cookiefile are undefined, it meas that the
+        API was called with --no-cache-credentials and no change will be
+        made
+        """
+        if self.tokenfile is None and self.cookiefile is None:
+            log.info("API Key won't be updated")
+            return
+
+        config_filename = _default_location('bugzillarc', kind='config')
+        section = _parse_hostname(self.url)
+
+        cfg = ConfigParser()
+        cfg.read(config_filename)
+
+        if section not in cfg.sections():
+            cfg.add_section(section)
+
+        cfg[section]['api_key'] = self.api_key.strip()
+
+        with open(config_filename, 'w') as configfile:
+            cfg.write(configfile)
+
+        log.info("API Key updated in %s", config_filename)
+
     def interactive_login(self, user=None, password=None, force=False,
-                          restrict_login=None):
+                          restrict_login=None, use_api_key=False):
         """
         Helper method to handle login for this bugzilla instance.
 
@@ -635,9 +663,28 @@ class Bugzilla(object):
         :param password: bugzilla password. If not specified, prompt for it.
         :param force: Unused
         :param restrict_login: restricts session to IP address
+        :param use_api_key: True if the login should be done using an api_key
         """
         ignore = force
         log.debug('Calling interactive_login')
+
+        if use_api_key:
+            sys.stdout.write('API Key: ')
+            sys.stdout.flush()
+            api_key = sys.stdin.readline().strip()
+
+            self.disconnect()
+            self.api_key = api_key
+
+            log.info('Checking API key... ')
+            self.connect()
+
+            if not self.logged_in:
+                raise BugzillaError("Login with API_KEY failed")
+            log.info('API Key acepted')
+
+            self._save_api_key()
+            return
 
         if not user:
             sys.stdout.write('Bugzilla Username: ')


### PR DESCRIPTION
This change introduces a new feature for the command line client
and the Bugzilla python API.

In the python API, it changes the interactive_login method
to receive a new flag: "use_api_key" that, in case is defined will
ask the user to provide an API key instead of regular username/password.

In case the API_KEY provide works correctly, it will also
update the ~/config/python-bugzilla/bugzillarc file (or ~/.bugzillarc).

In the bugzilla-cli side, it will add a new parameter to the login
command: "--use-key". Use key will trigger the usage of this new python API.

Default behaviors were not change, neither in bugzilla-cli or the python
API.

This patch introduce the changes to fix issue #82