### PR TITLE
Factor out rc-handling and listify

### DIFF
--- a/bugzilla/_cli.py
+++ b/bugzilla/_cli.py
@@ -101,8 +101,8 @@ def get_default_url():
     """
     Grab a default URL from bugzillarc [DEFAULT] url=X
     """
-    from bugzilla.base import _open_bugzillarc
-    cfg = _open_bugzillarc()
+    from bugzilla._rc import open_bugzillarc
+    cfg = open_bugzillarc()
     if cfg:
         cfgurl = cfg.defaults().get("url", None)
         if cfgurl is not None:

--- a/bugzilla/_rc.py
+++ b/bugzilla/_rc.py
@@ -1,0 +1,46 @@
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
+# the full text of the license.
+
+import os
+import sys
+from logging import getLogger
+
+# pylint: disable=import-error,no-name-in-module,ungrouped-imports
+if sys.version_info[0] >= 3:
+    from configparser import ConfigParser
+else:
+    from ConfigParser import SafeConfigParser as ConfigParser
+# pylint: enable=import-error,no-name-in-module,ungrouped-imports
+
+from ._util import listify
+
+log = getLogger(__name__)
+
+DEFAULT_CONFIGPATHS = [
+    '/etc/bugzillarc',
+    '~/.bugzillarc',
+    '~/.config/python-bugzilla/bugzillarc',
+]
+
+
+def open_bugzillarc(configpaths=-1):
+    if configpaths == -1:
+        configpaths = DEFAULT_CONFIGPATHS[:]
+
+    # pylint: disable=protected-access
+    configpaths = [os.path.expanduser(p) for p in
+                   listify(configpaths)]
+    # pylint: enable=protected-access
+    cfg = ConfigParser()
+    read_files = cfg.read(configpaths)
+    if not read_files:
+        return
+
+    log.info("Found bugzillarc files: %s", read_files)
+    return cfg
+
+
+

--- a/bugzilla/_util.py
+++ b/bugzilla/_util.py
@@ -1,0 +1,15 @@
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See http://www.gnu.org/copyleft/gpl.html for
+# the full text of the license.
+
+
+def listify(val):
+    """Ensure that value is either None or a list, converting single values
+    into 1-element lists"""
+    if val is None:
+        return val
+    if isinstance(val, list):
+        return val
+    return [val]

--- a/bugzilla/rhbugzilla.py
+++ b/bugzilla/rhbugzilla.py
@@ -12,6 +12,7 @@
 from logging import getLogger
 
 from .base import Bugzilla
+from ._util import listify
 
 log = getLogger(__name__)
 
@@ -77,7 +78,7 @@ class RHBugzilla(Bugzilla):
                 return
 
             if not isinstance(val, dict):
-                component = self._listify(kwargs.get("component"))
+                component = listify(kwargs.get("component"))
                 if not component:
                     raise ValueError("component must be specified if "
                         "specifying sub_component")
@@ -150,7 +151,7 @@ class RHBugzilla(Bugzilla):
         if ext_priority is not None:
             param_dict['ext_priority'] = ext_priority
         params = {
-            'bug_ids': self._listify(bug_ids),
+            'bug_ids': listify(bug_ids),
             'external_bugs': [param_dict],
         }
 
@@ -185,7 +186,7 @@ class RHBugzilla(Bugzilla):
         """
         params = {}
         if ids is not None:
-            params['ids'] = self._listify(ids)
+            params['ids'] = listify(ids)
         if ext_type_id is not None:
             params['ext_type_id'] = ext_type_id
         if ext_type_description is not None:
@@ -193,9 +194,9 @@ class RHBugzilla(Bugzilla):
         if ext_type_url is not None:
             params['ext_type_url'] = ext_type_url
         if ext_bz_bug_id is not None:
-            params['ext_bz_bug_id'] = self._listify(ext_bz_bug_id)
+            params['ext_bz_bug_id'] = listify(ext_bz_bug_id)
         if bug_ids is not None:
-            params['bug_ids'] = self._listify(bug_ids)
+            params['bug_ids'] = listify(bug_ids)
         if ext_status is not None:
             params['ext_status'] = ext_status
         if ext_description is not None:
@@ -229,7 +230,7 @@ class RHBugzilla(Bugzilla):
         """
         params = {}
         if ids is not None:
-            params['ids'] = self._listify(ids)
+            params['ids'] = listify(ids)
         if ext_type_id is not None:
             params['ext_type_id'] = ext_type_id
         if ext_type_description is not None:
@@ -237,9 +238,9 @@ class RHBugzilla(Bugzilla):
         if ext_type_url is not None:
             params['ext_type_url'] = ext_type_url
         if ext_bz_bug_id is not None:
-            params['ext_bz_bug_id'] = self._listify(ext_bz_bug_id)
+            params['ext_bz_bug_id'] = listify(ext_bz_bug_id)
         if bug_ids is not None:
-            params['bug_ids'] = self._listify(bug_ids)
+            params['bug_ids'] = listify(bug_ids)
 
         log.debug("Calling ExternalBugs.remove_external_bug(%s)", params)
         return self._proxy.ExternalBugs.remove_external_bug(params)
@@ -331,7 +332,7 @@ class RHBugzilla(Bugzilla):
         # support now, so point people to that instead so we don't have
         # to document and maintain this logic anymore
         def _warn_bool(kwkey):
-            vallist = self._listify(kwargs.get(kwkey, None))
+            vallist = listify(kwargs.get(kwkey, None))
             for value in vallist or []:
                 for s in value.split(" "):
                     if s not in ["|", "&", "!"]:


### PR DESCRIPTION
This is in preparation for #75.  The rcfile support is specific to the XMLPRC interface, and will eventually be removed from base.py, so let's factor it out now so that it is still available to the cli.  Also, listify is a generally-useful function and need not be a static method.