### PR TITLE
Added the new option "--desc_type".

### DIFF
--- a/bugzilla/_cli.py
+++ b/bugzilla/_cli.py
@@ -292,6 +292,7 @@ def _setup_action_query_parser(subparsers):
         help="Owner ID of the --savedsearch. You can get this ID from "
             "the URL bugzilla generates when running the saved search "
             "from the web UI.")
+    g.add_argument('--desc_type', help="Type of long_desc")
 
     # Keep this at the end so it sticks out more
     g.add_argument('--from-url', metavar="WEB_QUERY_URL",
@@ -520,6 +521,7 @@ def _do_query(bz, opt, parser):
         bug_id=opt.id or None,
         short_desc=opt.summary or None,
         long_desc=opt.comment or None,
+        desc_type=opt.desc_type or None,
         cc=opt.cc or None,
         assigned_to=opt.assigned_to or None,
         qa_contact=opt.qa_contact or None,
@@ -552,6 +554,7 @@ def _do_query(bz, opt, parser):
     _merge_field_opts(built_query, opt, parser)
 
     built_query.update(q)
+
     q = built_query
 
     if not q:  # pragma: no cover

--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -1154,6 +1154,7 @@ class Bugzilla(object):
                     component=None,
                     version=None,
                     long_desc=None,
+                    desc_type=None,
                     bug_id=None,
                     short_desc=None,
                     cc=None,
@@ -1281,7 +1282,11 @@ class Bugzilla(object):
         if long_desc is not None:
             query["query_format"] = "advanced"
             query["longdesc"] = long_desc
-            query["longdesc_type"] = "allwordssubstr"
+            if desc_type is not None:
+                query["longdesc_type"] = desc_type
+            else:
+                query["longdesc_type"] = "allwordssubstr"
+
 
         # 'include_fields' only available for Bugzilla4+
         # 'extra_fields' is an RHBZ extension

--- a/man/bugzilla.rst
+++ b/man/bugzilla.rst
@@ -342,6 +342,13 @@ in it), and --from-url will run it via the bugzilla API. Don't forget
 to quote the string! This only works for Bugzilla 5 and Red Hat
 bugzilla
 
+- ``--desc_type COMMENT_TYPE``
+
+Change how the search in the comments is made (any single word or 
+search for the exact same string, etc). Possible values are:
+allwordssubstr, anywordssubstr, substring, casesubstring,
+allwords, anywords, regexp, notregexp, equals.
+Default to allwordssubstr.
 
 ‘modify’ specific options
 =========================


### PR DESCRIPTION
This allows to modify how the search in comment (advanced) is performed.

Signed-off-by: Pierguido Lambri <plambri@redhat.com>

I've checked the tests, lint and tox and didn't see any more messages than what's reported on master.