### PR TITLE
setup: Check for rst2man.py as well

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+docutils


### PR DESCRIPTION
This is what docutils from pip installs. Compared to fedora
packages which rename it rst2man.

This should fix the issue that prompted 80c451e2f846, where
we made man page building non-fatal, so undo that to ensure
CI is hitting this build path.