### PR TITLE
cli: Add query --extrafield, --includefield, --excludefield

### DIFF
--- a/bugzilla/_cli.py
+++ b/bugzilla/_cli.py
@@ -163,6 +163,21 @@ def _parser_add_output_options(p):
             help="one line summary of the bug (useful for scripts)")
     outg.add_argument('--json', action='store_const', dest='output',
             const='json', help="output contents in json format")
+    outg.add_argument("--includefield", action="append",
+            help="Pass the field name to bugzilla include_fields list. "
+                 "Only the fields passed to include_fields are returned "
+                 "by the bugzilla server. "
+                 "This can be specified multiple times.")
+    outg.add_argument("--extrafield", action="append",
+            help="Pass the field name to bugzilla extra_fields list. "
+                 "When used with --json this can be used to request "
+                 "bugzilla to return values for non-default fields. "
+                 "This can be specified multiple times.")
+    outg.add_argument("--excludefield", action="append",
+            help="Pass the field name to bugzilla exclude_fields list. "
+                 "When used with --json this can be used to request "
+                 "bugzilla to not return values for a field. "
+                 "This can be specified multiple times.")
     outg.add_argument('--raw', action='store_const', dest='output',
             const='raw', help="raw output of the bugzilla contents. This "
             "format is unstable and difficult to parse. Use --json instead.")
@@ -750,7 +765,21 @@ def _bug_field_repl_cb(bz, b, matchobj):
 
 def _format_output(bz, opt, buglist):
     if opt.output in ['raw', 'json']:
-        buglist = bz.getbugs([b.bug_id for b in buglist])
+        include_fields = None
+        exclude_fields = None
+        extra_fields = None
+
+        if opt.includefield:
+            include_fields = opt.includefield
+        if opt.excludefield:
+            exclude_fields = opt.excludefield
+        if opt.extrafield:
+            extra_fields = opt.extrafield
+
+        buglist = bz.getbugs([b.bug_id for b in buglist],
+                include_fields=include_fields,
+                exclude_fields=exclude_fields,
+                extra_fields=extra_fields)
         if opt.output == 'json':
             _format_output_json(buglist)
         if opt.output == 'raw':

--- a/man/bugzilla.rst
+++ b/man/bugzilla.rst
@@ -272,6 +272,27 @@ one line summary of the bug (useful for scripts)
 
 output bug contents in JSON format
 
+- ``--includefield``
+
+Pass the field name to bugzilla include_fields list.
+Only the fields passed to include_fields are returned
+by the bugzilla server.
+This can be specified multiple times.
+
+- ``--extrafield``
+
+Pass the field name to bugzilla extra_fields list.
+When used with --json this can be used to request
+bugzilla to return values for non-default fields.
+This can be specified multiple times.
+
+- ``--excludefield``
+
+Pass the field name to bugzilla exclude_fields list.
+When used with --json this can be used to request
+bugzilla to not return values for a field.
+This can be specified multiple times.
+
 - ``--raw``
 
 raw output of the bugzilla contents. This format is unstable and

--- a/tests/data/clioutput/test_query9.txt
+++ b/tests/data/clioutput/test_query9.txt
@@ -1,0 +1,250 @@
+{
+  "bugs": [
+    {
+      "actual_time": 0.0,
+      "alias": [],
+      "assigned_to": "lvm-team@redhat.com",
+      "assigned_to_detail": {
+        "email": "lvm-team@redhat.com",
+        "id": 206817,
+        "name": "lvm-team@redhat.com",
+        "real_name": "LVM and device-mapper development team"
+      },
+      "blocks": [
+        123456
+      ],
+      "cc": [
+        "example@redhat.com",
+        "example2@redhat.com"
+      ],
+      "cc_detail": [
+        {
+          "email": "example@redhat.com",
+          "id": 123456,
+          "name": "example@redhat.com",
+          "real_name": "Example user"
+        },
+        {
+          "email": "example2@redhat.com",
+          "id": 123457,
+          "name": "heinzm@redhat.com",
+          "real_name": "Example2 user"
+        }
+      ],
+      "cf_build_id": "",
+      "cf_conditional_nak": [],
+      "cf_cust_facing": "---",
+      "cf_doc_type": "Bug Fix",
+      "cf_environment": "",
+      "cf_last_closed": "2016-03-03T22:15:07",
+      "cf_partner": [],
+      "cf_pgm_internal": "",
+      "cf_pm_score": "0",
+      "cf_qe_conditional_nak": [],
+      "cf_release_notes": "",
+      "cf_target_upstream_version": "",
+      "cf_verified": [],
+      "classification": "Red Hat",
+      "comments": [
+        {
+          "bug_id": 1165434,
+          "count": 0,
+          "creation_time": "2014-11-19T00:26:50",
+          "creator": "example@redhat.com",
+          "creator_id": 276776,
+          "id": 7685441,
+          "is_private": false,
+          "tags": [],
+          "text": "Description of problem:\nVersion-Release number of selected component (if applicable):\nkernel-2.6.18-308.el5\ndevice-mapper-multipath-0.4.7-48.el5\ndevice-mapper-1.02.67-2.el5\ndevice-mapper-1.02.67-2.el5\ndevice-mapper-event-1.02.67-2.el5\n",
+          "time": "2014-11-19T00:26:50"
+        },
+        {
+          "bug_id": 1165434,
+          "count": 1,
+          "creation_time": "2014-11-19T00:47:57",
+          "creator": "example@redhat.com",
+          "creator_id": 276776,
+          "id": 7685467,
+          "is_private": false,
+          "tags": [],
+          "text": "We can see that there is a dmeventd task that has sent data over a socket and is waiting for the peer to respond:\n\ncrash> bt\nany interaction with the filesystem until it has issued the suspend command to convert the mirror device to a linear device.",
+          "time": "2014-11-19T00:47:57"
+        },
+        {
+          "bug_id": 1165434,
+          "count": 2,
+          "creation_time": "2014-11-19T01:53:53",
+          "creator": "example@redhat.com",
+          "creator_id": 156796,
+          "id": 7685595,
+          "is_private": false,
+          "tags": [],
+          "text": "Test text",
+          "time": "2014-11-19T01:53:53"
+        }
+      ],
+      "depends_on": [
+        112233
+      ],
+      "devel_whiteboard": "somedeveltag,someothertag",
+      "docs_contact": "",
+      "estimated_time": 0.0,
+      "external_bugs": [
+        {
+          "bug_id": 989253,
+          "ext_bz_bug_id": "703421",
+          "ext_bz_id": 3,
+          "ext_description": "None",
+          "ext_priority": "None",
+          "ext_status": "None",
+          "id": 115528,
+          "type": {
+            "can_get": true,
+            "can_send": false,
+            "description": "GNOME Bugzilla",
+            "full_url": "https://bugzilla.gnome.org/show_bug.cgi?id=%id%",
+            "id": 3,
+            "must_send": false,
+            "send_once": false,
+            "type": "Bugzilla",
+            "url": "https://bugzilla.gnome.org"
+          }
+        },
+        {
+          "bug_id": 989253,
+          "ext_bz_bug_id": "1203576",
+          "ext_bz_id": 29,
+          "ext_description": "None",
+          "ext_priority": "None",
+          "ext_status": "None",
+          "id": 115527,
+          "type": {
+            "can_get": false,
+            "can_send": false,
+            "description": "Launchpad",
+            "full_url": "https://bugs.launchpad.net/bugs/%id%",
+            "id": 29,
+            "must_send": false,
+            "send_once": false,
+            "type": "None",
+            "url": "https://bugs.launchpad.net/bugs"
+          }
+        }
+      ],
+      "fixed_in": "",
+      "flags": [
+        {
+          "creation_date": "2019-11-15T21:57:21Z",
+          "id": 4302313,
+          "is_active": 1,
+          "modification_date": "2019-11-15T21:57:21Z",
+          "name": "qe_test_coverage",
+          "setter": "pm-rhel@redhat.com",
+          "status": "?",
+          "type_id": 318
+        },
+        {
+          "creation_date": "2018-12-25T16:47:43Z",
+          "id": 3883137,
+          "is_active": 1,
+          "modification_date": "2018-12-25T16:47:43Z",
+          "name": "release",
+          "setter": "rule-engine@redhat.com",
+          "status": "?",
+          "type_id": 1197
+        },
+        {
+          "creation_date": "2018-12-25T16:47:38Z",
+          "id": 3883134,
+          "is_active": 1,
+          "modification_date": "2018-12-25T16:47:38Z",
+          "name": "pm_ack",
+          "setter": "example3@redhat.com",
+          "status": "?",
+          "type_id": 11
+        },
+        {
+          "creation_date": "2018-12-25T16:47:38Z",
+          "id": 3883135,
+          "is_active": 1,
+          "modification_date": "2018-12-25T16:47:38Z",
+          "name": "devel_ack",
+          "setter": "example2@redhat.com",
+          "status": "?",
+          "type_id": 10
+        },
+        {
+          "creation_date": "2018-12-25T16:47:38Z",
+          "id": 3883136,
+          "is_active": 1,
+          "modification_date": "2019-04-28T02:07:03Z",
+          "name": "qa_ack",
+          "setter": "example@redhat.com",
+          "status": "+",
+          "type_id": 9
+        },
+        {
+          "creation_date": "2019-03-29T06:50:01Z",
+          "id": 3999302,
+          "is_active": 1,
+          "modification_date": "2019-03-29T06:50:01Z",
+          "name": "needinfo",
+          "requestee": "hello@example.com",
+          "setter": "example@redhat.com",
+          "status": "?",
+          "type_id": 1164
+        }
+      ],
+      "groups": [
+        "somegroup"
+      ],
+      "id": 1165434,
+      "internal_whiteboard": "someinternal TAG",
+      "is_cc_accessible": true,
+      "is_confirmed": true,
+      "is_creator_accessible": true,
+      "is_open": false,
+      "keywords": [
+        "key1",
+        "keyword2",
+        "Security"
+      ],
+      "last_change_time": "2018-12-09T19:12:12",
+      "op_sys": "Linux",
+      "platform": "All",
+      "priority": "medium",
+      "product": "Red Hat Enterprise Linux 5",
+      "qa_contact": "mspqa-list@redhat.com",
+      "qa_contact_detail": {
+        "email": "mspqa-list@redhat.com",
+        "id": 164197,
+        "name": "mspqa-list@redhat.com",
+        "real_name": "Cluster QE"
+      },
+      "qa_whiteboard": "foo bar baz",
+      "remaining_time": 0.0,
+      "resolution": "WONTFIX",
+      "see_also": [],
+      "severity": "medium",
+      "status": "CLOSED",
+      "sub_component": "dmeventd (RHEL5)",
+      "sub_components": {
+        "lvm2": [
+          "dmeventd (RHEL5)"
+        ]
+      },
+      "summary": "LVM mirrored root can deadlock dmeventd if a mirror leg is lost",
+      "tags": [],
+      "target_milestone": "rc",
+      "target_release": [
+        "---"
+      ],
+      "url": "",
+      "version": "5.8",
+      "versions": [
+        "5.8"
+      ],
+      "whiteboard": "genericwhiteboard"
+    }
+  ]
+}

--- a/tests/data/mockargs/test_getbug_query9.txt
+++ b/tests/data/mockargs/test_getbug_query9.txt
@@ -1,0 +1,13 @@
+([1165434],
+ [],
+ {'exclude_fields': ['excludeme'],
+  'extra_fields': ['extrame1',
+                   'extrame2',
+                   'comments',
+                   'description',
+                   'external_bugs',
+                   'flags',
+                   'sub_components',
+                   'tags'],
+  'include_fields': ['foo', 'bar', 'id'],
+  'permissive': 1})

--- a/tests/data/mockargs/test_query9.txt
+++ b/tests/data/mockargs/test_query9.txt
@@ -1,0 +1,1 @@
+{'id': ['1165434'], 'include_fields': ['id']}

--- a/tests/test_cli_query.py
+++ b/tests/test_cli_query.py
@@ -132,3 +132,18 @@ def test_query(run_cli):
     tests.utils.diff_compare(tests.utils.sanitize_json(out),
         "data/clioutput/test_query8.txt")
     assert json.loads(out)
+
+    # Test --json output
+    cmd = ("bugzilla query --json --id 1165434 "
+           "--includefield foo --includefield bar "
+           "--excludefield excludeme "
+           "--extrafield extrame1 --extrafield extrame2 ")
+    fakebz = tests.mockbackend.make_bz(rhbz=True,
+        bug_search_args="data/mockargs/test_query9.txt",
+        bug_search_return={"bugs": [{"id": 1165434}]},
+        bug_get_args="data/mockargs/test_getbug_query9.txt",
+        bug_get_return="data/mockreturn/test_getbug_rhel.txt")
+    out = run_cli(cmd, fakebz)
+    tests.utils.diff_compare(tests.utils.sanitize_json(out),
+        "data/clioutput/test_query9.txt")
+    assert json.loads(out)

--- a/tests/test_ro_functional.py
+++ b/tests/test_ro_functional.py
@@ -229,6 +229,17 @@ def testQueryFixedIn(run_cli, backends):
     assert "#629311 CLOSED" in out
 
 
+def testQueryExtrafieldPool(run_cli, backends):
+    # rhbz has an agile 'pool' extension but doesn't return the field
+    # by default. Check that '-extrafield pool' returns it for --json output
+    bz = _open_bz(REDHAT_URL, **backends)
+
+    out1 = run_cli("bugzilla query --id 1717616 --json", bz)
+    out2 = run_cli("bugzilla query --id 1717616 --json --extrafield pool", bz)
+    assert "current_sprint_id" not in out1
+    assert "current_sprint_id" in out2
+
+
 def testComponentsDetails(backends):
     """
     Fresh call to getcomponentsdetails should properly refresh


### PR DESCRIPTION
Allow users to pass these extra/include/exclude values straight
through to the remote server.

For most of the output format options these don't add anything,
but for --json and --raw which do a getbug() call, these can be useful
for tweaking the output, like reducing the total returned data, or
requesting the server return a non-standard field.