### PR TITLE
bug: remove copied comment from base.py

### DIFF
--- a/bugzilla/bug.py
+++ b/bugzilla/bug.py
@@ -1,5 +1,3 @@
-# base.py - the base classes etc. for a Python interface to bugzilla
-#
 # Copyright (C) 2007, 2008, 2009, 2010 Red Hat Inc.
 # Author: Will Woods <wwoods@redhat.com>
 #


### PR DESCRIPTION
This comment was an accidental copy & paste from commit 72ba03a3dc3a69d4d09db51237f71aa6e6917b3e.