### PR TITLE
Add limit as option to build_query

### DIFF
--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -1197,7 +1197,8 @@ class Bugzilla(object):
                     sub_component=None,
                     tags=None,
                     exclude_fields=None,
-                    extra_fields=None):
+                    extra_fields=None,
+                    limit=None):
         """
         Build a query string from passed arguments. Will handle
         query parameter differences between various bugzilla versions.
@@ -1230,6 +1231,7 @@ class Bugzilla(object):
             "quicksearch": quicksearch,
             "savedsearch": savedsearch,
             "sharer_id": savedsearch_sharer_id,
+            "limit": limit,
 
             # RH extensions... don't add any more. See comment below
             "sub_components": listify(sub_component),


### PR DESCRIPTION
Problem: In queries where the number of bugs are too large,
usually we get a timeout
Solution: bugzilla API provides a limit option in queries.
This commit adds this option to the build_query method