### PR TITLE
support custom search queries

### DIFF
--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -1173,6 +1173,7 @@ class Bugzilla(object):
             params["j_top"] = q.connector
 
         i = 1
+
         def traverse(root):
             nonlocal i
             for node in root.children:
@@ -1180,7 +1181,8 @@ class Bugzilla(object):
                     key, value = node
                     op = "equals"
 
-                    # workaround because we cannot use dots in Python variable names
+                    # workaround because we cannot use dots in
+                    # Python variable names
                     key = key.replace("___", ".")
 
                     # custom operator (specified with field_name__operator)

--- a/bugzilla/query.py
+++ b/bugzilla/query.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2008-2021 Django Software Foundation and individual contributors.
+# License: BSD-3-Clause
+#
+# both classes are extracted from:
+# https://github.com/django/django/blob/f0480ddd2d3cb04b784cf7ea697f792b45c689cc/django/utils/tree.py
+# https://github.com/django/django/blob/f0480ddd2d3cb04b784cf7ea697f792b45c689cc/django/db/models/query_utils.py
+
+import copy
+
+
+class Node:
+    """
+    A single internal node in the tree graph. A Node should be viewed as a
+    connection (the root) with the children being either leaf nodes or other
+    Node instances.
+    """
+    # Standard connector type. Clients usually won't use this at all and
+    # subclasses will usually override the value.
+    default = 'DEFAULT'
+
+    def __init__(self, children=None, connector=None, negated=False):
+        """Construct a new Node. If no connector is given, use the default."""
+        self.children = children[:] if children else []
+        self.connector = connector or self.default
+        self.negated = negated
+
+    # Required because django.db.models.query_utils.Q. Q. __init__() is
+    # problematic, but it is a natural Node subclass in all other respects.
+    @classmethod
+    def _new_instance(cls, children=None, connector=None, negated=False):
+        """
+        Create a new instance of this class when new Nodes (or subclasses) are
+        needed in the internal code in this class. Normally, it just shadows
+        __init__(). However, subclasses with an __init__ signature that aren't
+        an extension of Node.__init__ might need to implement this method to
+        allow a Node to create a new instance of them (if they have any extra
+        setting up to do).
+        """
+        obj = Node(children, connector, negated)
+        obj.__class__ = cls
+        return obj
+
+    def __str__(self):
+        template = '(NOT (%s: %s))' if self.negated else '(%s: %s)'
+        return template % (self.connector, ', '.join(str(c) for c in self.children))
+
+    def __repr__(self):
+        return "<%s: %s>" % (self.__class__.__name__, self)
+
+    def __deepcopy__(self, memodict):
+        obj = Node(connector=self.connector, negated=self.negated)
+        obj.__class__ = self.__class__
+        obj.children = copy.deepcopy(self.children, memodict)
+        return obj
+
+    def __len__(self):
+        """Return the number of children this node has."""
+        return len(self.children)
+
+    def __bool__(self):
+        """Return whether or not this node has children."""
+        return bool(self.children)
+
+    def __contains__(self, other):
+        """Return True if 'other' is a direct child of this instance."""
+        return other in self.children
+
+    def __eq__(self, other):
+        return (
+            self.__class__ == other.__class__ and
+            self.connector == other.connector and
+            self.negated == other.negated and
+            self.children == other.children
+        )
+
+    def add(self, data, conn_type):
+        """
+        Combine this tree and the data represented by data using the
+        connector conn_type. The combine is done by squashing the node other
+        away if possible.
+        This tree (self) will never be pushed to a child node of the
+        combined tree, nor will the connector or negated properties change.
+        Return a node which can be used in place of data regardless if the
+        node other got squashed or not.
+        """
+        if self.connector != conn_type:
+            obj = self._new_instance(self.children, self.connector, self.negated)
+            self.connector = conn_type
+            self.children = [obj, data]
+            return data
+        elif (
+            isinstance(data, Node) and
+            not data.negated and
+            (data.connector == conn_type or len(data) == 1)
+        ):
+            # We can squash the other node's children directly into this node.
+            # We are just doing (AB)(CD) == (ABCD) here, with the addition that
+            # if the length of the other node is 1 the connector doesn't
+            # matter. However, for the len(self) == 1 case we don't want to do
+            # the squashing, as it would alter self.connector.
+            self.children.extend(data.children)
+            return self
+        else:
+            # We could use perhaps additional logic here to see if some
+            # children could be used for pushdown here.
+            self.children.append(data)
+            return data
+
+    def negate(self):
+        """Negate the sense of the root connector."""
+        self.negated = not self.negated
+
+
+class Q(Node):
+    """
+    Encapsulate filters as objects that can then be combined logically (using
+    `&` and `|`).
+    """
+    # Connection types
+    AND = 'AND'
+    OR = 'OR'
+    default = AND
+    conditional = True
+
+    def __init__(self, *args, _connector=None, _negated=False, **kwargs):
+        super().__init__(children=[*args, *sorted(kwargs.items())], connector=_connector, negated=_negated)
+
+    def _combine(self, other, conn):
+        if not(isinstance(other, Q) or getattr(other, 'conditional', False) is True):
+            raise TypeError(other)
+
+        if not self:
+            return other.copy() if hasattr(other, 'copy') else copy.copy(other)
+        elif isinstance(other, Q) and not other:
+            _, args, kwargs = self.deconstruct()
+            return type(self)(*args, **kwargs)
+
+        obj = type(self)()
+        obj.connector = conn
+        obj.add(self, conn)
+        obj.add(other, conn)
+        return obj
+
+    def __or__(self, other):
+        return self._combine(other, self.OR)
+
+    def __and__(self, other):
+        return self._combine(other, self.AND)
+
+    def __invert__(self):
+        obj = type(self)()
+        # note: the following lines differs from upstream Django
+        # ~OR(...) in Django gives (NOT (AND: (OR: (...)))) instead of (NOT (OR: (...)))
+        # which is logical equivalent, but not desired in this case
+        #obj.add(self, self.AND)
+        obj.connector = self.connector
+        obj.add(self, self.connector)
+        obj.negate()
+        return obj
+
+    def deconstruct(self):
+        path = '%s.%s' % (self.__class__.__module__, self.__class__.__name__)
+        if path.startswith('django.db.models.query_utils'):
+            path = path.replace('django.db.models.query_utils', 'django.db.models')
+        args = tuple(self.children)
+        kwargs = {}
+        if self.connector != self.default:
+            kwargs['_connector'] = self.connector
+        if self.negated:
+            kwargs['_negated'] = True
+        return path, args, kwargs

--- a/examples/query.py
+++ b/examples/query.py
@@ -8,6 +8,7 @@
 import time
 
 import bugzilla
+from bugzilla.query import Q
 
 # public test instance of bugzilla.redhat.com. It's okay to make changes
 URL = "bugzilla.stage.redhat.com"
@@ -52,6 +53,18 @@ bugs = bzapi.query(query)
 t2 = time.time()
 print("Quicker query processing time: %s" % (t2 - t1))
 
+
+# You can run custom search queries by using the bugzilla.query.Q class
+# This class can be chained with & (AND) and | (OR) and queries can be
+# negated (~). More examples of complex queries can be found in the
+# test_custom_search.py unit tests.
+# The following query searches for
+# product = "Fedora" AND component = "python-bugzilla" AND (Fixed in Version = "1" OR Fixed in Version contains the string "2.")
+query = bzapi.build_query(
+    product="Fedora",
+    component="python-bugzilla",
+    custom=Q(cf_fixed_in="1") | Q(cf_fixed_in__substring="2."))
+bugs = bzapi.query(query)
 
 # bugzilla.redhat.com, and bugzilla >= 5.0 support queries using the same
 # format as is used for 'advanced' search URLs via the Web UI. For example,

--- a/examples/query.py
+++ b/examples/query.py
@@ -59,7 +59,9 @@ print("Quicker query processing time: %s" % (t2 - t1))
 # negated (~). More examples of complex queries can be found in the
 # test_custom_search.py unit tests.
 # The following query searches for
-# product = "Fedora" AND component = "python-bugzilla" AND (Fixed in Version = "1" OR Fixed in Version contains the string "2.")
+# product = "Fedora" AND component = "python-bugzilla" AND (
+#   Fixed in Version = "1" OR Fixed in Version contains the string "2."
+# )
 query = bzapi.build_query(
     product="Fedora",
     component="python-bugzilla",

--- a/tests/test_custom_search.py
+++ b/tests/test_custom_search.py
@@ -27,8 +27,7 @@ def makeurl(params):
 def test_custom_search_empty_itm():
     query = rhbz.build_query(custom=Q(itm__substring="---") | Q(itm__isempty=True))
     assert (
-        makeurl(query)
-        == "https://bugzilla.redhat.com/query.cgi?f1=cf_internal_target_milestone&f2=cf_internal_target_milestone&j_top=OR&o1=substring&o2=isempty&query_format=advanced&v1=---"
+        makeurl(query) == "https://bugzilla.redhat.com/query.cgi?f1=cf_internal_target_milestone&f2=cf_internal_target_milestone&j_top=OR&o1=substring&o2=isempty&query_format=advanced&v1=---"
     )
 
 
@@ -41,8 +40,7 @@ def test_custom_search_needinfo():
         ),
     )
     assert (
-        makeurl(query)
-        == "https://bugzilla.redhat.com/query.cgi?bug_status=NEW&bug_status=ASSIGNED&bug_status=POST&bug_status=MODIFIED&bug_status=ON_DEV&bug_status=ON_QA&bug_status=VERIFIED&f1=product&f2=requestees.login_name&o1=substring&o2=anyexact&query_format=advanced&v1=Red+Hat&v2=john%40redhat.com%2Calice%40redhat.com"
+        makeurl(query) == "https://bugzilla.redhat.com/query.cgi?bug_status=NEW&bug_status=ASSIGNED&bug_status=POST&bug_status=MODIFIED&bug_status=ON_DEV&bug_status=ON_QA&bug_status=VERIFIED&f1=product&f2=requestees.login_name&o1=substring&o2=anyexact&query_format=advanced&v1=Red+Hat&v2=john%40redhat.com%2Calice%40redhat.com"
     )
 
 
@@ -56,22 +54,21 @@ def test_custom_search_missed_deadline():
         ),
     )
     assert (
-        makeurl(query)
-        == "https://bugzilla.redhat.com/query.cgi?bug_status=NEW&bug_status=ASSIGNED&bug_status=POST&bug_status=MODIFIED&bug_status=ON_DEV&bug_status=ON_QA&f1=cf_deadline&f2=cf_deadline&f3=agile_pool.name&o1=isnotempty&o2=lessthan&o3=substring&query_format=advanced&v2=today&v3=sst_abc_"
+        makeurl(query) == "https://bugzilla.redhat.com/query.cgi?bug_status=NEW&bug_status=ASSIGNED&bug_status=POST&bug_status=MODIFIED&bug_status=ON_DEV&bug_status=ON_QA&f1=cf_deadline&f2=cf_deadline&f3=agile_pool.name&o1=isnotempty&o2=lessthan&o3=substring&query_format=advanced&v2=today&v3=sst_abc_"
     )
 
 
 def test_custom_search_stale_bugs():
     bugs_except = (
-        Q(flagtypes___name__anywordssubstr=["abc+", "def+"])
-        | Q(
+        Q(flagtypes___name__anywordssubstr=["abc+", "def+"]) |
+        Q(
             keywords__anywords=[
                 "keyword1",
                 "keyword2",
                 "keyword3",
             ]
-        )
-        | Q(external_bugzilla___description__casesubstring="Red Hat Portal")
+        ) |
+        Q(external_bugzilla___description__casesubstring="Red Hat Portal")
     )
 
     query = rhbz.build_query(
@@ -85,8 +82,7 @@ def test_custom_search_stale_bugs():
         ),
     )
     assert (
-        makeurl(query)
-        == "https://bugzilla.redhat.com/query.cgi?bug_status=__open__&f1=OP&f2=flagtypes.name&f3=keywords&f4=external_bugzilla.description&f5=CP&f6=cf_devel_whiteboard&f7=cf_final_deadline&f8=cf_final_deadline&f9=agile_pool.name&j1=OR&n1=1&o2=anywordssubstr&o3=anywords&o4=casesubstring&o6=notsubstring&o7=isnotempty&o8=lessthan&o9=substring&query_format=advanced&v2=abc%2B%2Cdef%2B&v3=keyword1%2Ckeyword2%2Ckeyword3&v4=Red+Hat+Portal&v6=AllowAutoClosure&v8=%2B30d&v9=sst_abc_"
+        makeurl(query) == "https://bugzilla.redhat.com/query.cgi?bug_status=__open__&f1=OP&f2=flagtypes.name&f3=keywords&f4=external_bugzilla.description&f5=CP&f6=cf_devel_whiteboard&f7=cf_final_deadline&f8=cf_final_deadline&f9=agile_pool.name&j1=OR&n1=1&o2=anywordssubstr&o3=anywords&o4=casesubstring&o6=notsubstring&o7=isnotempty&o8=lessthan&o9=substring&query_format=advanced&v2=abc%2B%2Cdef%2B&v3=keyword1%2Ckeyword2%2Ckeyword3&v4=Red+Hat+Portal&v6=AllowAutoClosure&v8=%2B30d&v9=sst_abc_"
     )
 
 
@@ -101,8 +97,7 @@ def test_custom_search_bugs_dev_without_dtm():
         ),
     )
     assert (
-        makeurl(query)
-        == "https://bugzilla.redhat.com/query.cgi?bug_status=__open__&f1=OP&f2=bug_status&f3=cf_fixed_in&f4=CP&f5=OP&f6=cf_dev_target_milestone&f7=CP&f8=cf_deadline_type&f9=agile_pool.name&j1=OR&j5=AND&n5=1&o2=anyexact&o3=isempty&o6=anyexact&o8=nowordssubstr&o9=substring&query_format=advanced&v2=NEW%2CASSIGNED&v6=1%2C2%2C3%2C4%2C5%2C6%2C7%2C8%2C9%2C10&v8=DevCustom%2CCustom&v9=sst_abc_"
+        makeurl(query) == "https://bugzilla.redhat.com/query.cgi?bug_status=__open__&f1=OP&f2=bug_status&f3=cf_fixed_in&f4=CP&f5=OP&f6=cf_dev_target_milestone&f7=CP&f8=cf_deadline_type&f9=agile_pool.name&j1=OR&j5=AND&n5=1&o2=anyexact&o3=isempty&o6=anyexact&o8=nowordssubstr&o9=substring&query_format=advanced&v2=NEW%2CASSIGNED&v6=1%2C2%2C3%2C4%2C5%2C6%2C7%2C8%2C9%2C10&v8=DevCustom%2CCustom&v9=sst_abc_"
     )
 
 
@@ -110,8 +105,8 @@ def test_custom_search_bugs_awaiting_verification():
     query = rhbz.build_query(
         status="__open__",
         custom=Q(
-            Q(bug_status__nowordssubstr=["NEW", "ASSIGNED"])
-            | Q(cf_fixed_in__isnotempty=True),
+            Q(bug_status__nowordssubstr=["NEW", "ASSIGNED"]) |
+            Q(cf_fixed_in__isnotempty=True),
             pool__substring="sst_abc_",
             bug_status__notequals="VERIFIED",
             cf_deadline__lessthaneq="+14d",
@@ -119,6 +114,5 @@ def test_custom_search_bugs_awaiting_verification():
         ),
     )
     assert (
-        makeurl(query)
-        == "https://bugzilla.redhat.com/query.cgi?bug_status=__open__&f1=OP&f2=bug_status&f3=cf_fixed_in&f4=CP&f5=bug_status&f6=cf_deadline&f7=cf_deadline&f8=agile_pool.name&j1=OR&o2=nowordssubstr&o3=isnotempty&o5=notequals&o6=greaterthaneq&o7=lessthaneq&o8=substring&query_format=advanced&v2=NEW%2CASSIGNED&v5=VERIFIED&v6=today&v7=%2B14d&v8=sst_abc_"
+        makeurl(query) == "https://bugzilla.redhat.com/query.cgi?bug_status=__open__&f1=OP&f2=bug_status&f3=cf_fixed_in&f4=CP&f5=bug_status&f6=cf_deadline&f7=cf_deadline&f8=agile_pool.name&j1=OR&o2=nowordssubstr&o3=isnotempty&o5=notequals&o6=greaterthaneq&o7=lessthaneq&o8=substring&query_format=advanced&v2=NEW%2CASSIGNED&v5=VERIFIED&v6=today&v7=%2B14d&v8=sst_abc_"
     )

--- a/tests/test_custom_search.py
+++ b/tests/test_custom_search.py
@@ -1,0 +1,124 @@
+#
+# Copyright Red Hat, Inc. 2021
+#
+# This work is licensed under the GNU GPLv2 or later.
+# See the COPYING file in the top-level directory.
+#
+
+"""
+Unit tests that examines custom search queries.
+"""
+import collections
+import urllib.parse
+from bugzilla.query import Q
+import tests
+
+rhbz = tests.mockbackend.make_bz(rhbz=True)
+
+
+def makeurl(params):
+    base_url = "https://bugzilla.redhat.com/query.cgi?"
+    # sort order in regular dicts (as returned by build_query()) is not defined
+    # let's sort it before comparing it to the expected URLs
+    sorted_params = collections.OrderedDict(sorted(params.items()))
+    return base_url + urllib.parse.urlencode(sorted_params, doseq=True)
+
+
+def test_custom_search_empty_itm():
+    query = rhbz.build_query(custom=Q(itm__substring="---") | Q(itm__isempty=True))
+    assert (
+        makeurl(query)
+        == "https://bugzilla.redhat.com/query.cgi?f1=cf_internal_target_milestone&f2=cf_internal_target_milestone&j_top=OR&o1=substring&o2=isempty&query_format=advanced&v1=---"
+    )
+
+
+def test_custom_search_needinfo():
+    query = rhbz.build_query(
+        status=["NEW", "ASSIGNED", "POST", "MODIFIED", "ON_DEV", "ON_QA", "VERIFIED"],
+        custom=Q(
+            product__substring="Red Hat",
+            requestees___login_name__anyexact=["john@redhat.com", "alice@redhat.com"],
+        ),
+    )
+    assert (
+        makeurl(query)
+        == "https://bugzilla.redhat.com/query.cgi?bug_status=NEW&bug_status=ASSIGNED&bug_status=POST&bug_status=MODIFIED&bug_status=ON_DEV&bug_status=ON_QA&bug_status=VERIFIED&f1=product&f2=requestees.login_name&o1=substring&o2=anyexact&query_format=advanced&v1=Red+Hat&v2=john%40redhat.com%2Calice%40redhat.com"
+    )
+
+
+def test_custom_search_missed_deadline():
+    query = rhbz.build_query(
+        status=["NEW", "ASSIGNED", "POST", "MODIFIED", "ON_DEV", "ON_QA"],
+        custom=Q(
+            pool__substring="sst_abc_",
+            cf_deadline__lessthan="today",
+            cf_deadline__isnotempty=True,
+        ),
+    )
+    assert (
+        makeurl(query)
+        == "https://bugzilla.redhat.com/query.cgi?bug_status=NEW&bug_status=ASSIGNED&bug_status=POST&bug_status=MODIFIED&bug_status=ON_DEV&bug_status=ON_QA&f1=cf_deadline&f2=cf_deadline&f3=agile_pool.name&o1=isnotempty&o2=lessthan&o3=substring&query_format=advanced&v2=today&v3=sst_abc_"
+    )
+
+
+def test_custom_search_stale_bugs():
+    bugs_except = (
+        Q(flagtypes___name__anywordssubstr=["abc+", "def+"])
+        | Q(
+            keywords__anywords=[
+                "keyword1",
+                "keyword2",
+                "keyword3",
+            ]
+        )
+        | Q(external_bugzilla___description__casesubstring="Red Hat Portal")
+    )
+
+    query = rhbz.build_query(
+        status="__open__",
+        custom=Q(
+            ~bugs_except,
+            pool__substring="sst_abc_",
+            cf_final_deadline__lessthan="+30d",
+            cf_final_deadline__isnotempty=None,
+            cf_devel_whiteboard__notsubstring="AllowAutoClosure",
+        ),
+    )
+    assert (
+        makeurl(query)
+        == "https://bugzilla.redhat.com/query.cgi?bug_status=__open__&f1=OP&f2=flagtypes.name&f3=keywords&f4=external_bugzilla.description&f5=CP&f6=cf_devel_whiteboard&f7=cf_final_deadline&f8=cf_final_deadline&f9=agile_pool.name&j1=OR&n1=1&o2=anywordssubstr&o3=anywords&o4=casesubstring&o6=notsubstring&o7=isnotempty&o8=lessthan&o9=substring&query_format=advanced&v2=abc%2B%2Cdef%2B&v3=keyword1%2Ckeyword2%2Ckeyword3&v4=Red+Hat+Portal&v6=AllowAutoClosure&v8=%2B30d&v9=sst_abc_"
+    )
+
+
+def test_custom_search_bugs_dev_without_dtm():
+    query = rhbz.build_query(
+        status="__open__",
+        custom=Q(
+            Q(bug_status__anyexact=["NEW", "ASSIGNED"]) | Q(cf_fixed_in__isempty=True),
+            ~Q(dtm__anyexact=range(1, 10 + 1)),
+            pool__substring="sst_abc_",
+            cf_deadline_type__nowordssubstr=["DevCustom", "Custom"],
+        ),
+    )
+    assert (
+        makeurl(query)
+        == "https://bugzilla.redhat.com/query.cgi?bug_status=__open__&f1=OP&f2=bug_status&f3=cf_fixed_in&f4=CP&f5=OP&f6=cf_dev_target_milestone&f7=CP&f8=cf_deadline_type&f9=agile_pool.name&j1=OR&j5=AND&n5=1&o2=anyexact&o3=isempty&o6=anyexact&o8=nowordssubstr&o9=substring&query_format=advanced&v2=NEW%2CASSIGNED&v6=1%2C2%2C3%2C4%2C5%2C6%2C7%2C8%2C9%2C10&v8=DevCustom%2CCustom&v9=sst_abc_"
+    )
+
+
+def test_custom_search_bugs_awaiting_verification():
+    query = rhbz.build_query(
+        status="__open__",
+        custom=Q(
+            Q(bug_status__nowordssubstr=["NEW", "ASSIGNED"])
+            | Q(cf_fixed_in__isnotempty=True),
+            pool__substring="sst_abc_",
+            bug_status__notequals="VERIFIED",
+            cf_deadline__lessthaneq="+14d",
+            cf_deadline__greaterthaneq="today",
+        ),
+    )
+    assert (
+        makeurl(query)
+        == "https://bugzilla.redhat.com/query.cgi?bug_status=__open__&f1=OP&f2=bug_status&f3=cf_fixed_in&f4=CP&f5=bug_status&f6=cf_deadline&f7=cf_deadline&f8=agile_pool.name&j1=OR&o2=nowordssubstr&o3=isnotempty&o5=notequals&o6=greaterthaneq&o7=lessthaneq&o8=substring&query_format=advanced&v2=NEW%2CASSIGNED&v5=VERIFIED&v6=today&v7=%2B14d&v8=sst_abc_"
+    )


### PR DESCRIPTION
This PR introduces support for custom search queries. They're based on the `Q` class of Django [1] and support arbitrary complex/nested queries connected with AND, OR and support negation.

`pycodestyle` is not happy with the long URLs in `test_custom_search.py`, I'm not sure what I should do about that - should I really break up the URLs and concat them with Python? `tox` runs fine, except on Python 3.4 and 3.5 which isn't available on Fedora 35 (those two Python versions are EOL already).

This PR shouldn't break anything and is fully backwards compatible, as the new `custom=` argument in the `build_query` function is `None` by default, and then no (new) code of this PR is run at all.

[1] https://docs.djangoproject.com/en/3.2/topics/db/queries/#complex-lookups-with-q-objects