### PR TITLE
minor docs change: fixing wrong documentation link

### DIFF
--- a/man/bugzilla.rst
+++ b/man/bugzilla.rst
@@ -859,4 +859,4 @@ SEE ALSO
 ========
 
 https://bugzilla.readthedocs.io/en/latest/api/index.html
-https://bugzilla.redhat.com/docs/en/html/api/Bugzilla/WebService/Bug.html
+https://bugzilla.redhat.com/docs/en/html/api/core/v1/bug.html


### PR DESCRIPTION
This solves the problem found in #161
The old link referred to the deprecated APIs.