### PR TITLE
rest api: Post process bugzilla code on HTTP error

### DIFF
--- a/bugzilla/_backendrest.py
+++ b/bugzilla/_backendrest.py
@@ -7,7 +7,7 @@ import logging
 import os
 
 from ._backendbase import _BackendBase
-from .exceptions import BugzillaError
+from .exceptions import BugzillaError, BugzillaHTTPError
 from ._util import listify
 
 
@@ -32,6 +32,23 @@ class _BackendREST(_BackendBase):
     #########################
     # Internal REST helpers #
     #########################
+    def _handle_error(self, e):
+        response = getattr(e, "response", None)
+        if response is None:
+            raise e
+
+        if response.status_code in [400, 401, 404]:
+            self._handle_error_response(response.text)
+        raise e
+
+    def _handle_error_response(self, text):
+        try:
+            result = json.loads(text)
+        except json.JSONDecodeError:
+            return
+
+        if result.get("error"):
+            raise BugzillaError(result["message"], code=result["code"])
 
     def _handle_response(self, text):
         try:
@@ -55,8 +72,13 @@ class _BackendREST(_BackendBase):
         else:
             data = json.dumps(paramdict or {})
 
-        response = self._bugzillasession.request(method, fullurl, data=data,
-                params=authparams)
+        try:
+            response = self._bugzillasession.request(
+                method, fullurl, data=data, params=authparams
+            )
+        except BugzillaHTTPError as e:
+            self._handle_error(e)
+
         return self._handle_response(response.text)
 
     def _get(self, *args, **kwargs):

--- a/bugzilla/_session.py
+++ b/bugzilla/_session.py
@@ -9,6 +9,7 @@ import urllib.parse
 
 import requests
 
+from .exceptions import BugzillaHTTPError
 
 log = getLogger(__name__)
 
@@ -106,9 +107,12 @@ class _BugzillaSession(object):
 
         try:
             response.raise_for_status()
-        except Exception as e:
+        except requests.HTTPError as e:
             # Scrape the api key out of the returned exception string
             message = str(e).replace(self._api_key or "", "")
-            raise type(e)(message).with_traceback(sys.exc_info()[2])
+            response = getattr(e, "response", None)
+            raise BugzillaHTTPError(message, response=response).with_traceback(
+                sys.exc_info()[2]
+            )
 
         return response

--- a/bugzilla/exceptions.py
+++ b/bugzilla/exceptions.py
@@ -1,5 +1,6 @@
 # This work is licensed under the GNU GPLv2 or later.
 # See the COPYING file in the top-level directory.
+from requests import HTTPError
 
 
 class BugzillaError(Exception):
@@ -36,3 +37,7 @@ class BugzillaError(Exception):
         if self.code:
             message += " (code=%s)" % self.code
         Exception.__init__(self, message)
+
+
+class BugzillaHTTPError(HTTPError):
+    """Error raised in the Bugzilla session"""

--- a/tests/test_rw_functional.py
+++ b/tests/test_rw_functional.py
@@ -50,8 +50,8 @@ def _check_have_admin(bz):
     return ret
 
 
-def test0LoggedInNoCreds():
-    bz = _open_bz(use_creds=False)
+def test0LoggedInNoCreds(backends):
+    bz = _open_bz(**backends, use_creds=False)
     assert not bz.logged_in
 
 


### PR DESCRIPTION
Bugzilla REST API map result codes to HTTP status codes: https://github.com/bugzilla/bugzilla/blob/7581e08f9136ec32219af6c3192e42ff1c8e9691/Bugzilla/WebService/Constants.pm#L262-L287

But python-bugzilla don't propagate those Bugzilla codes.

Fixes: https://github.com/python-bugzilla/python-bugzilla/issues/171