### PR TITLE
Set `Bug.weburl` that is compatible with the REST API (fixes #178)

### DIFF
--- a/bugzilla/bug.py
+++ b/bugzilla/bug.py
@@ -6,6 +6,7 @@
 
 import copy
 from logging import getLogger
+from urllib.parse import urlparse, urlunparse
 
 
 log = getLogger(__name__)
@@ -39,8 +40,15 @@ class Bug(object):
             dict["id"] = bug_id
 
         self._update_dict(dict)
-        self.weburl = bugzilla.url.replace('xmlrpc.cgi',
-                                           'show_bug.cgi?id=%i' % self.bug_id)
+        self.weburl = self._generate_weburl()
+
+    def _generate_weburl(self):
+        """
+        Generate the URL to the bug in the web UI
+        """
+        parsed = urlparse(self.bugzilla.url)
+        return urlunparse((parsed.scheme, parsed.netloc, 'show_bug.cgi', '', 'id=%s' % self.bug_id,
+                           ''))
 
     def __str__(self):
         """

--- a/tests/data/clioutput/test_query2.txt
+++ b/tests/data/clioutput/test_query2.txt
@@ -57,7 +57,7 @@ ATTRIBUTE[target_milestone]: rc
 ATTRIBUTE[target_release]: ['---']
 ATTRIBUTE[url]: 
 ATTRIBUTE[version]: ['5.8']
-ATTRIBUTE[weburl]: https:///TESTSUITEMOCK
+ATTRIBUTE[weburl]: https:///show_bug.cgi?id=1165434
 ATTRIBUTE[whiteboard]: genericwhiteboard
 
 

--- a/tests/test_api_bug.py
+++ b/tests/test_api_bug.py
@@ -184,3 +184,12 @@ def test_bug_apis():
     attachments = bug.get_attachments()
     bug.attachments = attachments
     assert [469147, 470041, 502352] == bug.get_attachment_ids()
+
+
+def test_bug_weburl():
+    fakebz = tests.mockbackend.make_bz(
+        bug_get_args=None,
+        bug_get_return="data/mockreturn/test_getbug_rhel.txt")
+    bug_id = 1165434
+    bug = fakebz.getbug(bug_id)
+    assert bug.weburl == f"https:///show_bug.cgi?id={bug_id}"


### PR DESCRIPTION
Instead of replacing the substring 'xmlrpc.cgi' in the Bugzilla URL, the URL is now constructed by explicitly using the `netloc` of the Bugzilla URL.