### PR TITLE
Use proper REST API route for getting a single bug (fixes #174)

### DIFF
--- a/bugzilla/_backendrest.py
+++ b/bugzilla/_backendrest.py
@@ -107,9 +107,17 @@ class _BackendREST(_BackendBase):
     def bug_fields(self, paramdict):
         return self._get("/field/bug", paramdict)
     def bug_get(self, bug_ids, aliases, paramdict):
+        bug_list = listify(bug_ids)
+        alias_list = listify(aliases)
         data = paramdict.copy()
-        data["id"] = listify(bug_ids)
-        data["alias"] = listify(aliases)
+
+        if len(bug_list or []) + len(alias_list or []) == 1:
+            for id_list in (bug_list, alias_list):
+                if id_list:
+                    return self._get("/bug/%s" % id_list[0], data)
+
+        data["id"] = bug_list
+        data["alias"] = alias_list
         ret = self._get("/bug", data)
         return ret
 

--- a/bugzilla/_backendrest.py
+++ b/bugzilla/_backendrest.py
@@ -111,6 +111,11 @@ class _BackendREST(_BackendBase):
         alias_list = listify(aliases)
         data = paramdict.copy()
 
+        # FYI: The high-level API expects the backends to raise an exception
+        # when retrieval of a single bug fails (default behavior of the XMLRPC
+        # API), but the REST API simply returns an empty search result set.
+        # To ensure compliant behavior, the REST backend needs to use the
+        # explicit URL to get a single bug.
         if len(bug_list or []) + len(alias_list or []) == 1:
             for id_list in (bug_list, alias_list):
                 if id_list:

--- a/tests/test_backend_rest.py
+++ b/tests/test_backend_rest.py
@@ -5,20 +5,21 @@ from bugzilla._session import _BugzillaSession
 
 
 def test_getbug():
+    session = _BugzillaSession(url="http://example.com",
+                               user_agent="py-bugzilla-test",
+                               sslverify=False,
+                               cert=None,
+                               tokencache={},
+                               api_key="",
+                               is_redhat_bugzilla=False)
     backend = _BackendREST(url="http://example.com",
-                           bugzillasession=_BugzillaSession(url="http://example.com",
-                                                            user_agent="py-bugzilla-test",
-                                                            sslverify=False,
-                                                            cert=None,
-                                                            tokencache={},
-                                                            api_key="",
-                                                            is_redhat_bugzilla=False))
+                           bugzillasession=session)
 
-    def _assertion(self, *args, **kwargs):
+    def _assertion(self, *args):
         self.assertion_called = True
         assert args and args[0] == url
 
-    backend._get = MethodType(_assertion, backend)
+    setattr(backend, "_get", MethodType(_assertion, backend))
 
     for _ids, aliases, url in (
             (1, None, "/bug/1"),

--- a/tests/test_backend_rest.py
+++ b/tests/test_backend_rest.py
@@ -1,0 +1,34 @@
+from types import MethodType
+
+from bugzilla._backendrest import _BackendREST
+from bugzilla._session import _BugzillaSession
+
+
+def test_getbug():
+    backend = _BackendREST(url="http://example.com",
+                           bugzillasession=_BugzillaSession(url="http://example.com",
+                                                            user_agent="py-bugzilla-test",
+                                                            sslverify=False,
+                                                            cert=None,
+                                                            tokencache={},
+                                                            api_key="",
+                                                            is_redhat_bugzilla=False))
+
+    def _assertion(self, *args, **kwargs):
+        self.assertion_called = True
+        assert args and args[0] == url
+
+    backend._get = MethodType(_assertion, backend)
+
+    for _ids, aliases, url in (
+            (1, None, "/bug/1"),
+            ([1], [], "/bug/1"),
+            (None, "CVE-1999-0001", "/bug/CVE-1999-0001"),
+            ([], ["CVE-1999-0001"], "/bug/CVE-1999-0001"),
+            (1, "CVE-1999-0001", "/bug"),
+    ):
+        backend.assertion_called = False
+
+        backend.bug_get(_ids, aliases, {})
+
+        assert backend.assertion_called is True


### PR DESCRIPTION
This avoids an `IndexError` in Bugzilla._getbug` and ensures that a `BugzillaError` gets raised e.g. if the bug ID does not exist or the client is not authorized.

closes #174 