### PR TITLE
Include `alias` in `include_fields` (closes #170)

### DIFF
--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -1081,6 +1081,14 @@ class Bugzilla(object):
             else:
                 ids.append(idstr)
 
+        if include_fields is not None and aliases and "alias" not in include_fields:
+            # Extra field to prevent sorting (see below) from cause an error
+            try:
+                include_fields.append("alias")
+            except AttributeError:
+                # Just in case somebody passed in a tuple or another non-list type
+                include_fields = list(include_fields) + ["alias"]
+
         extra_fields = listify(extra_fields or [])
         extra_fields += self._getbug_extra_fields()
 

--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -1083,13 +1083,8 @@ class Bugzilla(object):
 
         if (include_fields is not None and aliases
                 and "alias" not in include_fields):
-            # Extra field to prevent sorting (see below) from cause an error
-            try:
-                include_fields.append("alias")
-            except AttributeError:
-                # Just in case somebody passed in a tuple or another non-list
-                # type
-                include_fields = list(include_fields) + ["alias"]
+            # Extra field to prevent sorting (see below) from causing an error
+            include_fields.append("alias")
 
         extra_fields = listify(extra_fields or [])
         extra_fields += self._getbug_extra_fields()

--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -1081,12 +1081,14 @@ class Bugzilla(object):
             else:
                 ids.append(idstr)
 
-        if include_fields is not None and aliases and "alias" not in include_fields:
+        if (include_fields is not None and aliases
+                and "alias" not in include_fields):
             # Extra field to prevent sorting (see below) from cause an error
             try:
                 include_fields.append("alias")
             except AttributeError:
-                # Just in case somebody passed in a tuple or another non-list type
+                # Just in case somebody passed in a tuple or another non-list
+                # type
                 include_fields = list(include_fields) + ["alias"]
 
         extra_fields = listify(extra_fields or [])

--- a/tests/test_api_bug.py
+++ b/tests/test_api_bug.py
@@ -113,7 +113,10 @@ def test_getbug_alias():
 
     backend = getattr(fakebz, "_backend")
     setattr(backend, "bug_get", mock_bug_get)
-    bug = fakebz.getbug("CVE-1234-5678", include_fields=["id"])
+
+    fakebz.getbug("CVE-1234-5678", include_fields=["id"])
+    fakebz.getbug("CVE-1234-5678", include_fields="id")
+    fakebz.getbug("CVE-1234-5678", include_fields=("id",))
 
 
 def test_bug_getattr():

--- a/tests/test_api_bug.py
+++ b/tests/test_api_bug.py
@@ -115,8 +115,6 @@ def test_getbug_alias():
     setattr(backend, "bug_get", mock_bug_get)
 
     fakebz.getbug("CVE-1234-5678", include_fields=["id"])
-    fakebz.getbug("CVE-1234-5678", include_fields="id")
-    fakebz.getbug("CVE-1234-5678", include_fields=("id",))
 
 
 def test_bug_getattr():

--- a/tests/test_api_bug.py
+++ b/tests/test_api_bug.py
@@ -94,6 +94,28 @@ def test_api_getbugs():
     assert fakebz.getbugs(["123456", "CVE-1234-FAKE"]) == []
 
 
+def test_getbug_alias():
+    """
+    Test that `getbug(<alias>)` includes the alias in `include_fields`
+    """
+    fakebz = tests.mockbackend.make_bz(
+        bug_get_args=None,
+        bug_get_return="data/mockreturn/test_query_cve_getbug.txt")
+    bug = fakebz.getbug("CVE-1234-5678", include_fields=["id"])
+    assert bug.alias == ["CVE-1234-5678"]
+    assert bug.id == 123456
+
+    def mock_bug_get(bug_ids, aliases, paramdict):
+        assert bug_ids == []
+        assert aliases == ["CVE-1234-5678"]
+        assert "alias" in paramdict.get("include_fields", [])
+        return {"bugs": [bug.get_raw_data()]}
+
+    backend = getattr(fakebz, "_backend")
+    setattr(backend, "bug_get", mock_bug_get)
+    bug = fakebz.getbug("CVE-1234-5678", include_fields=["id"])
+
+
 def test_bug_getattr():
     fakebz = tests.mockbackend.make_bz(
         bug_get_args=None,

--- a/tests/test_ro_functional.py
+++ b/tests/test_ro_functional.py
@@ -330,6 +330,13 @@ def testGetBugAlias404(backends):
         raise AssertionError("No exception raised")
 
 
+def testGetBugAliasIncludedField(backends):
+    bz = _open_bz(REDHAT_URL, **backends)
+
+    bug = bz.getbug("CVE-2011-2527", include_fields=["id"])
+    assert bug.bug_id == 720773
+
+
 def testQuerySubComponent(run_cli, backends):
     bz = _open_bz(REDHAT_URL, **backends)
 


### PR DESCRIPTION
Include `alias` in `include_fields`, when the parameter for `getbug` is an alias (closes #170)

Because the `_getbugs` method tries to return bug data in the same order as IDs and aliases are provided, the `alias` needs to be explicitly added to `include_fields`.