### PR TITLE
ci: Fix packit RPM build locale errors

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,12 +52,16 @@ def pytest_ignore_collect(path, config):
 
 
 def pytest_configure(config):
-    try:
-        # Needed for test reproducibility on systems not using a UTF-8 locale
-        locale.setlocale(locale.LC_ALL, 'C')
-        locale.setlocale(locale.LC_CTYPE, 'en_US.UTF-8')
-    except Exception as e:
-        print("Error setting locale: %s" % str(e))
+    # Needed for test reproducibility on any system not using a UTF-8 locale
+    locale.setlocale(locale.LC_ALL, "C")
+    for loc in ["C.UTF-8", "C.utf8", "UTF-8", "en_US.UTF-8"]:
+        try:
+            locale.setlocale(locale.LC_CTYPE, loc)
+            break
+        except locale.Error:
+            pass
+    else:
+        raise locale.Error("No UTF-8 locale found")
 
     if config.getoption("--redhat-url"):
         tests.CLICONFIG.REDHAT_URL = config.getoption("--redhat-url")


### PR DESCRIPTION
Be more thorough trying to find a UTF-8 locale in minimal fedora buildroot

Lifted from https://gitlab.com/libosinfo/osinfo-db