### PR TITLE
CLI: always use API key for login to redhat.com

### DIFF
--- a/bugzilla/_cli.py
+++ b/bugzilla/_cli.py
@@ -1203,6 +1203,7 @@ def _handle_login(opt, action, bz):
     username = getattr(opt, "pos_username", None) or opt.username
     password = getattr(opt, "pos_password", None) or opt.password
     use_key = getattr(opt, "api_key", False)
+    use_key = use_key or "redhat.com" in bz.url
 
     try:
         if use_key:


### PR DESCRIPTION
Allowing username/password login to redhat.com bugzillas is now just a footgun that could get your account blocked, so let's not. Just always do API key login if redhat.com is in the URL.