### PR TITLE
session: Fix API leak pt2

### DIFF
--- a/bugzilla/_session.py
+++ b/bugzilla/_session.py
@@ -107,12 +107,15 @@ class _BugzillaSession(object):
                 response.encoding = "UTF-8"
 
             response.raise_for_status()
-        except requests.HTTPError as e:
+        except Exception as e:
             # Scrape the api key out of the returned exception string
             message = str(e).replace(self._api_key or "", "")
-            response = getattr(e, "response", None)
-            raise BugzillaHTTPError(message, response=response).with_traceback(
-                sys.exc_info()[2]
-            )
+            if isinstance(e, requests.HTTPError):
+                response = getattr(e, "response", None)
+                raise BugzillaHTTPError(
+                    message, response=response).with_traceback(
+                        sys.exc_info()[2])
+            raise type(e)(message).with_traceback(sys.exc_info()[2])
+
 
         return response

--- a/tests/test_ro_functional.py
+++ b/tests/test_ro_functional.py
@@ -74,6 +74,17 @@ def test_rest_xmlrpc_detection():
 def test_apikey_error_scraping():
     # Ensure the API key does not leak into any requests exceptions
     fakekey = "FOOBARMYKEY"
+
+    with pytest.raises(Exception) as e:
+        _open_bz("https://bugzilla.redhat.nopedontexist",
+                 force_rest=True, api_key=fakekey)
+    assert fakekey not in str(e.value)
+
+    with pytest.raises(Exception) as e:
+        _open_bz("https://bugzilla.redhat.nopedontexist",
+                 force_xmlrpc=True, api_key=fakekey)
+    assert fakekey not in str(e.value)
+
     with pytest.raises(Exception) as e:
         _open_bz("https://httpstat.us/502&foo",
                 force_xmlrpc=True, api_key=fakekey)


### PR DESCRIPTION
session: Fix API leak pt2

Between the time https://github.com/python-bugzilla/python-bugzilla/commit/182e0b0ba05c393f2a6ab81e02a1de8c2e04b7a3 was written, https://github.com/python-bugzilla/python-bugzilla/commit/138caf8aa72757329aa92c1acc66b4302486ac35 was committed
which inadvertently loosened up the api_key scraping.