### PR TITLE
cli: Support `--field` and `--field-json` for `bugzilla attach`

### DIFF
--- a/bugzilla/_cli.py
+++ b/bugzilla/_cli.py
@@ -186,7 +186,6 @@ def _parser_add_output_options(p):
 
 
 def _parser_add_field_passthrough_opts(p):
-    # Put this at the end, so it sticks out more
     p.add_argument('--field',
         metavar="FIELD=VALUE", action="append", dest="fields",
         help="Manually specify a bugzilla API field. FIELD is "

--- a/tests/data/mockargs/test_attach3.txt
+++ b/tests/data/mockargs/test_attach3.txt
@@ -1,0 +1,9 @@
+(['123456'],
+ 'STRIPPED-BY-TESTSUITE',
+ {'content_type': 'text/plain',
+  'file_name': 'bz-attach-get1.txt',
+  'flags': [{'name': 'review',
+             'requestee': 'crobinso@redhat.com',
+             'status': '-'}],
+  'is_obsolete': '1',
+  'summary': 'bz-attach-get1.txt'})

--- a/tests/test_cli_attach.py
+++ b/tests/test_cli_attach.py
@@ -49,6 +49,18 @@ def test_attach(run_cli):
     out = run_cli(cmd, fakebz, stdin=attachcontent)
     assert "Created attachment 1557949 on bug 123456" in out
 
+    # Test --field passthrough
+    cmd = "bugzilla attach 123456 --file=%s " % attachfile
+    cmd += "--field=is_obsolete=1 "
+    cmd += "--field-json "
+    cmd += ('\'{"flags": [{"name": "review"'
+            ', "requestee": "crobinso@redhat.com", "status": "-"}]}\'')
+    fakebz = tests.mockbackend.make_bz(
+        bug_attachment_create_args="data/mockargs/test_attach3.txt",
+        bug_attachment_create_return={'ids': [1557949]})
+    out = run_cli(cmd, fakebz)
+    assert "Created attachment 1557949 on bug 123456" in out
+
 
 def _test_attach_get(run_cli):
     # Hit error when using ids with --get*


### PR DESCRIPTION
Enables option passthrough for adding attachments too

Resolve: https://github.com/python-bugzilla/python-bugzilla/issues/169