### PR TITLE
Allow bug creation with an explicitly empty list of groups

### DIFF
--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -1761,7 +1761,7 @@ class Bugzilla(object):
             localdict["cc"] = listify(cc)
         if depends_on:
             localdict["depends_on"] = listify(depends_on)
-        if groups:
+        if groups is not None:
             localdict["groups"] = listify(groups)
         if keywords:
             localdict["keywords"] = listify(keywords)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,20 @@
+from bugzilla.base import Bugzilla
+
+
+def test_build_createbug():
+    bz = Bugzilla(url=None)
+
+    args = {"product": "Ubuntu 33⅓", "summary": "Hello World", "alias": "CVE-2024-0000"}
+    result = bz.build_createbug(**args)
+    assert result == args
+
+    result = bz.build_createbug(groups=None, **args)
+    assert result == args
+
+    args["groups"] = []
+    result = bz.build_createbug(**args)
+    assert result == args
+
+    args["groups"] += ["the-group"]
+    result = bz.build_createbug(**args)
+    assert result == args


### PR DESCRIPTION
This allows the caller of this method to create a bug with no groups assigned, even if server-side default group assignments are configured.

Closes #210