### PR TITLE
Fixed issue in `Bugzilla.fix_url`

### DIFF
--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -155,6 +155,9 @@ class Bugzilla(object):
             if force_rest:
                 path = "rest/"
 
+        if not path.startswith("/"):
+            path = "/" + path
+
         newurl = urllib.parse.urlunparse(
             (scheme, netloc, path, params, query, fragment))
         return newurl

--- a/bugzilla/bug.py
+++ b/bugzilla/bug.py
@@ -48,7 +48,7 @@ class Bug(object):
         """
         parsed = urlparse(self.bugzilla.url)
         return urlunparse((parsed.scheme, parsed.netloc,
-                           'show_bug.cgi', '', 'id=%s' % self.bug_id,
+                           '/show_bug.cgi', '', 'id=%s' % self.bug_id,
                            ''))
 
     def __str__(self):

--- a/tests/test_api_misc.py
+++ b/tests/test_api_misc.py
@@ -44,6 +44,7 @@ def test_fixurl():
         "https://example.com/xmlrpc.cgi")
     assert (bugzilla.Bugzilla.fix_url("http://example.com/somepath.cgi") ==
         "http://example.com/somepath.cgi")
+    assert bugzilla.Bugzilla.fix_url("http:///foo") == "http:///foo"
 
 
 def testPostTranslation():


### PR DESCRIPTION
In a new patch version of Python 3.12 the behavior of `urllib.parse.urlunparse` changed.

This change ensures that this method works correctly with the old and new behavior of `urllib.parse.urlunparse`.