### PR TITLE
fix: Emulate `permissive` on REST backend (closes #222)

### DIFF
--- a/bugzilla/_backendrest.py
+++ b/bugzilla/_backendrest.py
@@ -109,6 +109,7 @@ class _BackendREST(_BackendBase):
     def bug_get(self, bug_ids, aliases, paramdict):
         bug_list = listify(bug_ids)
         alias_list = listify(aliases)
+        permissive = paramdict.pop("permissive", False)
         data = paramdict.copy()
 
         # FYI: The high-level API expects the backends to raise an exception
@@ -116,7 +117,7 @@ class _BackendREST(_BackendBase):
         # API), but the REST API simply returns an empty search result set.
         # To ensure compliant behavior, the REST backend needs to use the
         # explicit URL to get a single bug.
-        if len(bug_list or []) + len(alias_list or []) == 1:
+        if not permissive and len(bug_list or []) + len(alias_list or []) == 1:
             for id_list in (bug_list, alias_list):
                 if id_list:
                     return self._get("/bug/%s" % id_list[0], data)

--- a/tests/test_backend_rest.py
+++ b/tests/test_backend_rest.py
@@ -42,3 +42,26 @@ class TestGetBug:
             backend.bug_get(_ids, aliases, {})
 
             assert backend.assertion_called is True
+
+    def test_getbug__permissive(self):
+        backend = self.backend
+
+        def _assertion(self, *args):
+            self.assertion_called = True
+            assert args and args[0] == url and args[1] == params
+
+        setattr(backend, "_get", MethodType(_assertion, backend))
+
+        for _ids, aliases, url, params in (
+                (1, None, "/bug", {"id": [1], "alias": None}),
+                ([1], [], "/bug", {"id": [1], "alias": []}),
+                (None, "CVE-1999-0001", "/bug", {"alias": ["CVE-1999-0001"], "id": None}),
+                ([], ["CVE-1999-0001"], "/bug", {"alias": ["CVE-1999-0001"], "id": []}),
+                (1, "CVE-1999-0001", "/bug", {"id": [1], "alias": ["CVE-1999-0001"]}),
+                ([1, 2], None, "/bug", {"id": [1, 2], "alias": None})
+        ):
+            backend.assertion_called = False
+
+            backend.bug_get(_ids, aliases, {"permissive": True})
+
+            assert backend.assertion_called is True


### PR DESCRIPTION
`_BackendREST.bug_get` cannot pass a `permissive` parameter to the server as the REST API does not honor such a parameter.

With this change, permissiveness is handled inside the method:

If `permissive` is false and a single ID or alias is requested, the "get" method is used and an exception gets raised in case of error.
Otherwise, the "search" method is used, which may return an empty list, if the client is not authenticated or an ID or alias does not exist.

closes #222 