### PR TITLE
Some redhat functional test suite fixes

### DIFF
--- a/tests/test_rw_functional.py
+++ b/tests/test_rw_functional.py
@@ -534,8 +534,10 @@ def test071ModifyMisc(run_cli, backends):
         assert targetbug.target_milestone == "rc"
         assert targetbug.target_release == ["6.10"]
     except RuntimeError as e:
-        if have_dev:
-            raise
+        # As of Nov 2024 this needs even extra permissions, probably
+        # due to RHEL products being locked down
+        # if have_dev:
+        #    raise
         assert perm_error in str(e)
 
     try:


### PR DESCRIPTION
See individual commits for details

test_xmlrpc_bad_url is still failing. Not sure if this is due to a change on example.com or something with requests library. The goal is to trigger the code in _backendxmlrpc that appends the error 'The URL may not be an XMLRPC URL'. Poking at it quickly I couldn't figure out how to handle that. Maybe we can just rip that code out.