### PR TITLE
Support "resolution" in `Bug.build_query`

### DIFF
--- a/bugzilla/base.py
+++ b/bugzilla/base.py
@@ -1205,7 +1205,8 @@ class Bugzilla(object):
                     tags=None,
                     exclude_fields=None,
                     extra_fields=None,
-                    limit=None):
+                    limit=None,
+                    resolution=None):
         """
         Build a query string from passed arguments. Will handle
         query parameter differences between various bugzilla versions.
@@ -1239,6 +1240,7 @@ class Bugzilla(object):
             "savedsearch": savedsearch,
             "sharer_id": savedsearch_sharer_id,
             "limit": limit,
+            "resolution": resolution,
 
             # RH extensions... don't add any more. See comment below
             "sub_components": listify(sub_component),

--- a/tests/integration/ro_api_test.py
+++ b/tests/integration/ro_api_test.py
@@ -223,3 +223,16 @@ def test_login_stubs(mocked_responses, backends):
 
     # Works fine when not logged in
     bz.logout()
+
+
+def test_query_resolution(mocked_responses, backends):
+    bz = open_bz(url=TEST_URL, **backends)
+
+    bugs = bz.query(bz.build_query(short_desc="ZeroDivisionError", resolution=None))
+    assert len(bugs) == 1
+
+    bugs = bz.query(bz.build_query(short_desc="ZeroDivisionError", resolution="---"))
+    assert len(bugs) == 1
+
+    bugs = bz.query(bz.build_query(short_desc="ZeroDivisionError", resolution="DUPLICATE"))
+    assert len(bugs) == 0


### PR DESCRIPTION
This change allows to search and filter bugs by resolution.

Closes #231.