### PR TITLE
man: fix section name from [DEFAULTS] to [DEFAULT]

### DIFF
--- a/man/bugzilla.1
+++ b/man/bugzilla.1
@@ -588,7 +588,7 @@ set per hostname section are
 \fBcert\fP: default client side certificate
 .UNINDENT
 .sp
-A \fB[DEFAULTS]\fP section is also accepted, which takes the following
+A \fB[DEFAULT]\fP section is also accepted, which takes the following
 values:
 .INDENT 0.0
 .IP \(bu 2

--- a/man/bugzilla.rst
+++ b/man/bugzilla.rst
@@ -825,7 +825,7 @@ set per hostname section are
 - ``cert``: default client side certificate
 
 
-A ``[DEFAULTS]`` section is also accepted, which takes the following
+A ``[DEFAULT]`` section is also accepted, which takes the following
 values:
 
 - ``url``: default bugzilla URL


### PR DESCRIPTION
Corrected the section header from [DEFAULTS] to [DEFAULT] in both the troff and reStructuredText documentation files. This aligns the docs with the actual expected configuration section name.